### PR TITLE
Fix Docker CLI installation for Ubuntu Noble base image

### DIFF
--- a/docker/Dockerfile.custom-runner
+++ b/docker/Dockerfile.custom-runner
@@ -8,7 +8,7 @@ ARG KUBECONFORM_VERSION=v0.7.0
 ARG KUBESEC_VERSION=v2.14.2
 ARG HELM_VERSION=v3.18.6
 ARG TERRAFORM_VERSION=1.12.2-1
-ARG DOCKER_VERSION=5:28.3.3-1~ubuntu.22.04~jammy
+# Docker CLI installed as latest version (no longer pinning to specific Ubuntu release)
 ARG BUILDX_VERSION=v0.27.0
 ARG BUILDX_CHECKSUM=4f5e5a1b6dd0d6ff8476c8def7602d1eeedcb6f602e8dcd45079d352247eba06
 ARG PYTHON_VERSION=3.13
@@ -145,7 +145,6 @@ ARG PYTHON_VERSION
 ARG NODE_VERSION
 ARG HELM_VERSION
 ARG TERRAFORM_VERSION
-ARG DOCKER_VERSION
 ARG BUILDX_VERSION
 ARG BUILDX_CHECKSUM
 
@@ -244,7 +243,7 @@ RUN set -ex && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
     apt-get update && \
-    apt-get install -y docker-ce-cli=${DOCKER_VERSION} && \
+    apt-get install -y docker-ce-cli && \
     # Install GitHub CLI \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \


### PR DESCRIPTION
## Summary
- Remove hardcoded Ubuntu Jammy (22.04) version string for docker-ce-cli
- Install latest docker-ce-cli without version pinning

## Problem
The base image `ghcr.io/actions/actions-runner:latest` now uses Ubuntu Noble (24.04), but the Docker version string `5:28.3.3-1~ubuntu.22.04~jammy` was for Ubuntu Jammy (22.04).

Error: `E: Version '5:28.3.3-1~ubuntu.22.04~jammy' for 'docker-ce-cli' was not found`

## Solution
Install latest docker-ce-cli without version pinning, which will work regardless of the Ubuntu version.

## Test plan
- [ ] Build workflow completes successfully
- [ ] Runner image is pushed to registry
- [ ] All tools verified working
- [ ] Runners pick up queued jobs