### PR TITLE
Bump aquasecurity/trivy-action to v0.36.0

### DIFF
--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -167,7 +167,7 @@ jobs:
           echo "✅ Successfully authenticated with DigitalOcean Container Registry for Trivy"
       
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.32.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest
           format: sarif


### PR DESCRIPTION
## Summary
The `aquasecurity/trivy-action@0.32.0` reference no longer resolves; the security-scan job on the main-branch image rebuild (run 25342677623) failed at `Set up job`:

```
Error: Unable to resolve action 'aquasecurity/trivy-action@0.32.0', unable to find version '0.32.0'
```

The 0.32.x tag has been withdrawn upstream (and the project's tagging convention transitioned to v-prefixed tags). Current available tags are `v0.33.1`, `v0.34.0`, `v0.35.0` / `0.35.0`, and `v0.36.0` (latest).

Pinning to `v0.36.0` restores the post-build vulnerability scan. The build-and-push job from PR #10 already succeeded so the new runner image is in the registry and runners are picking up jobs again — this PR just fixes the optional scan job.

## Test plan
- [ ] PR build runs (no security-scan on PRs since `if: github.event_name != 'pull_request'`, but build-and-push will exercise the workflow)
- [ ] After merge, main-branch security-scan job actually runs and either succeeds or surfaces real Trivy findings