### PR TITLE
feat: add WeasyPrint native libs to runner image

### DIFF
--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -124,9 +124,10 @@ jobs:
           docker run --rm "$IMG" doctl version | grep -q 1.160
           docker run --rm "$IMG" kubectl version --client -o json | grep -q '"gitVersion": "v1.36'
           docker run --rm "$IMG" kubesec version | grep -vq '0.0.0'
-          # WeasyPrint native libs must load via ctypes (consumer CI jobs that
-          # `import weasyprint` fail at collection otherwise). Loading the bare
-          # sonames exercises the exact dlopen path WeasyPrint uses.
+          # WeasyPrint's hard (import-time) native libs must load via ctypes —
+          # consumer CI jobs that `import weasyprint` fail at collection
+          # otherwise. These mirror the consumer app's production image; the
+          # optional HarfBuzz subset lib (allow_fail in WeasyPrint) is omitted.
           docker run --rm "$IMG" python3 -c 'import ctypes; [ctypes.CDLL(n) for n in ("libpango-1.0.so.0","libpangoft2-1.0.so.0","libharfbuzz.so.0","libfontconfig.so.1","libcairo.so.2","libffi.so.8")]; print("WEASYPRINT_LIBS_OK")' | grep -q WEASYPRINT_LIBS_OK
           DV=$(docker run --rm "$IMG" docker --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           echo "Docker CLI: $DV"
@@ -314,7 +315,8 @@ jobs:
           docker run --rm "$IMG" kubectl version --client -o json | grep -q '"gitVersion": "v1.36'
           docker run --rm "$IMG" doctl version | grep -q 1.160
           docker run --rm "$IMG" kubesec version | grep -vq '0.0.0'
-          # WeasyPrint native libs (consumer CI jobs import weasyprint).
+          # WeasyPrint's hard (import-time) native libs (consumer CI jobs
+          # import weasyprint); optional HarfBuzz subset lib omitted by design.
           docker run --rm "$IMG" python3 -c 'import ctypes; [ctypes.CDLL(n) for n in ("libpango-1.0.so.0","libpangoft2-1.0.so.0","libharfbuzz.so.0","libfontconfig.so.1","libcairo.so.2","libffi.so.8")]; print("WEASYPRINT_LIBS_OK")' | grep -q WEASYPRINT_LIBS_OK
           echo "✅ All tools present and reporting real versions"
       

--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -124,6 +124,10 @@ jobs:
           docker run --rm "$IMG" doctl version | grep -q 1.160
           docker run --rm "$IMG" kubectl version --client -o json | grep -q '"gitVersion": "v1.36'
           docker run --rm "$IMG" kubesec version | grep -vq '0.0.0'
+          # WeasyPrint native libs must load via ctypes (consumer CI jobs that
+          # `import weasyprint` fail at collection otherwise). Loading the bare
+          # sonames exercises the exact dlopen path WeasyPrint uses.
+          docker run --rm "$IMG" python3 -c 'import ctypes; [ctypes.CDLL(n) for n in ("libpango-1.0.so.0","libpangoft2-1.0.so.0","libharfbuzz.so.0","libfontconfig.so.1","libcairo.so.2","libffi.so.8")]; print("WEASYPRINT_LIBS_OK")' | grep -q WEASYPRINT_LIBS_OK
           DV=$(docker run --rm "$IMG" docker --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           echo "Docker CLI: $DV"
           LOW=$(printf '%s\n28.3.3\n' "$DV" | sort -V | head -1)
@@ -310,6 +314,8 @@ jobs:
           docker run --rm "$IMG" kubectl version --client -o json | grep -q '"gitVersion": "v1.36'
           docker run --rm "$IMG" doctl version | grep -q 1.160
           docker run --rm "$IMG" kubesec version | grep -vq '0.0.0'
+          # WeasyPrint native libs (consumer CI jobs import weasyprint).
+          docker run --rm "$IMG" python3 -c 'import ctypes; [ctypes.CDLL(n) for n in ("libpango-1.0.so.0","libpangoft2-1.0.so.0","libharfbuzz.so.0","libfontconfig.so.1","libcairo.so.2","libffi.so.8")]; print("WEASYPRINT_LIBS_OK")' | grep -q WEASYPRINT_LIBS_OK
           echo "✅ All tools present and reporting real versions"
       
       - name: Upload Trivy scan results to GitHub Security tab

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ docker push registry.digitalocean.com/redducklabs/github-runner:latest
 - uv 0.11.17 (Python package/installer manager)
 - Go 1.26.3 runtime (for CI workflows that build Go)
 - Git, curl, wget, jq, zip, unzip, bc, libmagic1
+- WeasyPrint native libs (libpango, libpangoft2, libharfbuzz, libfontconfig,
+  libcairo2, libffi8) so consumer CI jobs that `import weasyprint` (PDF
+  rendering) can load them via ctypes
 
 ### Infrastructure Tools
 - Terraform 1.15.5
@@ -166,8 +169,10 @@ fingerprint is asserted before use. Node and Terraform are exact-version sources
 (Node via nodejs.org tarball + SHA256; Terraform via apt exact pin). Docker
 CLI/Compose-plugin and GitHub CLI **float** (key-verified; Docker CLI has a smoke
 floor of 28.3.3). Ubuntu-archive packages (`postgresql-client`, `redis-tools`,
-`bc`, `libmagic1`, `gettext-base`, `libpq-dev`, base runtime deps) float as
-distro-managed. Everything else is pinned + checksum/GPG-verified.
+`bc`, `libmagic1`, `gettext-base`, `libpq-dev`, the WeasyPrint native libs
+`libpango-1.0-0`/`libpangoft2-1.0-0`/`libharfbuzz0b`/`libfontconfig1`/`libcairo2`/`libffi8`,
+base runtime deps) float as distro-managed. Everything else is pinned +
+checksum/GPG-verified.
 
 **AWS CLI signing key rotation**: the AWS CLI v2 signing key (fingerprint
 `A6310ACC4672475C`, full `FB5D B77F D5C1 18B8 0511 ADA8 A631 0ACC 4672 475C`) is

--- a/docker/Dockerfile.custom-runner
+++ b/docker/Dockerfile.custom-runner
@@ -144,7 +144,16 @@ ENV PATH=${GOROOT}/bin:${GOPATH}/bin:${PATH}
 ENV GO111MODULE=on
 ENV CGO_ENABLED=1
 
-# Update and install runtime dependencies only (no build tools)
+# Update and install runtime dependencies only (no build tools).
+#
+# WeasyPrint native libraries (libpango-* / libharfbuzz / libfontconfig /
+# libcairo2 / libffi8): consumer CI jobs that `import weasyprint` (e.g.
+# aurolegal.ai's backend pytest suite) load these shared objects via ctypes at
+# import time. Without them, `import weasyprint` fails at collection with
+# `OSError: cannot load library 'libpango-1.0-0'`. This set mirrors the consumer
+# app's own runtime image (aurolegal.ai backend/Dockerfile) so the runner image
+# can host that backend test job. WeasyPrint >= 64 no longer hard-requires
+# gdk-pixbuf, so it is intentionally omitted.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     curl wget git \
@@ -154,7 +163,9 @@ RUN apt-get update && \
     software-properties-common \
     apt-transport-https \
     jq zip unzip tar gzip \
-    sudo && \
+    sudo \
+    libpango-1.0-0 libpangoft2-1.0-0 libharfbuzz0b \
+    libfontconfig1 libcairo2 libffi8 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Python via python-build-standalone (no Launchpad/PPA dependency)

--- a/docker/Dockerfile.custom-runner
+++ b/docker/Dockerfile.custom-runner
@@ -9,8 +9,11 @@ ARG TRIVY_VERSION=v0.70.0
 ARG TRIVY_SHA256=8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9
 ARG KUBECTL_VERSION=v1.36.1
 ARG KUBECTL_SHA256=629d3f410e09bf49b64ae7079f7f0bda1191efed311f7d37fdbab0ad5b0ec2b7
-ARG DOCTL_VERSION=v1.160.0
-ARG DOCTL_SHA256=b0a23eb02a213e6418e6d5b7dcd5207b6b70a5a5b15e8fcaadc0b8715ac0a735
+# doctl v1.160.0 was withdrawn upstream (the release/asset now 404s, breaking
+# the build); v1.160.1 is the current stable patch. SHA256 from DigitalOcean's
+# published doctl-1.160.1-checksums.sha256.
+ARG DOCTL_VERSION=v1.160.1
+ARG DOCTL_SHA256=615b03e678ffe391b3f3a3afe74a125f7fde1842135b7c3528862eba9ff16168
 # kubeconform and kubesec are built from source in the go-builder stage (their
 # upstream release binaries are below the CVE floor), so only the version pins
 # are needed here -- no download checksum.
@@ -152,8 +155,12 @@ ENV CGO_ENABLED=1
 # import time. Without them, `import weasyprint` fails at collection with
 # `OSError: cannot load library 'libpango-1.0-0'`. This set mirrors the consumer
 # app's own runtime image (aurolegal.ai backend/Dockerfile) so the runner image
-# can host that backend test job. WeasyPrint >= 64 no longer hard-requires
-# gdk-pixbuf, so it is intentionally omitted.
+# can host that backend test job AND so PDF rendering in CI matches the
+# consumer's production rendering path. WeasyPrint >= 64 no longer hard-requires
+# gdk-pixbuf, so it is omitted. libharfbuzz-subset0 is also intentionally
+# omitted: WeasyPrint loads it with allow_fail=True (optional PDF font
+# subsetting; FontTools fallback otherwise) and the consumer's production image
+# does not ship it, so matching that keeps CI rendering identical to prod.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     curl wget git \

--- a/test/verify-tools.sh
+++ b/test/verify-tools.sh
@@ -67,6 +67,17 @@ print('✓ All Python packages available')
 "
 echo ""
 
+# Test WeasyPrint native libraries (consumer CI jobs that import weasyprint load
+# these shared objects via ctypes; without them import fails at collection).
+echo -e "${BLUE}Testing WeasyPrint native libraries:${NC}"
+kubectl exec -n arc-runners "$RUNNER_POD" -c runner -- python3 -c "
+import ctypes
+for so in ('libpango-1.0.so.0', 'libpangoft2-1.0.so.0', 'libharfbuzz.so.0', 'libfontconfig.so.1', 'libcairo.so.2', 'libffi.so.8'):
+    ctypes.CDLL(so)
+print('✓ WeasyPrint native libraries loadable')
+"
+echo ""
+
 # Test security tools
 test_tool "kubeconform 0.7.0" "kubeconform -v"
 test_tool "kubesec 2.14.2" "kubesec version"


### PR DESCRIPTION
## Summary

Add WeasyPrint's native libraries to the custom runner image so consumer CI jobs that `import weasyprint` can run on the `redducklabs-runners` fleet.

`redducklabs/aurolegal.ai`'s backend pytest suite imports `weasyprint` (PDF letter rendering) at collection time. WeasyPrint loads Pango/Cairo/HarfBuzz/Fontconfig/FFI shared objects via `ctypes`, so without them collection fails immediately with:

```
OSError: cannot load library 'libpango-1.0-0': cannot open shared object file: No such file or directory
```

This was surfaced concretely: migrating that repo's `Backend Tests` job to `redducklabs-runners` proved the postgres `services:` container and `psql` work on the fleet, but pytest then failed on the missing Pango lib.

## Change

- `docker/Dockerfile.custom-runner`: add `libpango-1.0-0`, `libpangoft2-1.0-0`, `libharfbuzz0b`, `libfontconfig1`, `libcairo2`, `libffi8` to the runtime-dependencies apt layer (alongside `libpq-dev`/`libmagic1`). This mirrors the consumer app's own `backend/Dockerfile` so CI PDF rendering matches the consumer's production path. WeasyPrint ≥ 64 dropped the hard gdk-pixbuf dependency, so it is omitted. The optional `libharfbuzz-subset0` (WeasyPrint loads it `allow_fail=True`; FontTools fallback otherwise) is also intentionally omitted to match the consumer's production image. `libffi8` is already present in the base image (Python depends on it) — listed explicitly as defense-in-depth.
- `.github/workflows/build-runner-image.yml`: extend both the PR smoke test and the pushed-image verification to load the six **hard import-time** sonames via `ctypes.CDLL(...)` and assert `WEASYPRINT_LIBS_OK` (fails closed under `set -e`).
- `test/verify-tools.sh`: add the same `ctypes` load check against a live pod.
- `README.md`: document the libs in the toolchain + package-pinning sections.

### Folded-in prerequisite: doctl pin fix

The image build was already red on `main` (independent of WeasyPrint): the pinned **doctl `v1.160.0` was withdrawn upstream** and its release asset now 404s (`wget` exit 8). Bumped to the current stable **`v1.160.1`** with the SHA256 from DigitalOcean's published `doctl-1.160.1-checksums.sha256`. Verified every other pinned download after doctl (trivy, helm, buildx, uv, awscli, node, go) still returns HTTP 200 — doctl was the only yanked pin. The build's `doctl version | grep 1.160` assertions still match.

## Security / standards

- The WeasyPrint libs are distro-managed Ubuntu-archive runtime libraries that **float** like the other base runtime deps (`postgresql-client`, `libmagic1`, `libpq-dev`); they don't touch the CVE-floor / source-build posture. The doctl change keeps the pin+SHA256 model intact. CVE-floor gate and Trivy (report-only) unchanged.
- No tool downgrades (doctl is a forward patch bump), no source-build changes, no secret/permission changes.

## Verification

- Pre-flight (local): `apt-get install --dry-run` of all six packages against the actual base image `ghcr.io/actions/actions-runner:2.334.0` resolves cleanly (Ubuntu noble); `libffi.so.8` confirmed already present.
- **CI green:** the `build-and-push` job built `rdl-runner:pr`, downloaded doctl `v1.160.1` (SHA verified), ran the in-container WeasyPrint `ctypes` smoke test (passed), `ALL_TOOLS_OK`, and the enforcing CVE-floor gate (passed).
- Workflow YAML + `verify-tools.sh` shell syntax validated locally.

After this merges, the build-and-push on `main` pushes the new image, the fleet must be **redeployed** to pick it up, and then the consumer-side follow-up `redducklabs/aurolegal.ai#895` flips that repo's `Backend Tests` job to `redducklabs-runners`.

Enables redducklabs/aurolegal.ai#895. Part of the redducklabs-runners migration (redducklabs/aurolegal.ai#820, Phase 3 remainder).
