### PR TITLE
fix: deploy-runners passes cluster NAME (not context) to kubeconfig save

### DIFF
--- a/.github/workflows/deploy-runners.yml
+++ b/.github/workflows/deploy-runners.yml
@@ -38,6 +38,13 @@ on:
         type: string
 
 env:
+  # CLUSTER_NAME is the DigitalOcean cluster NAME (what `doctl kubernetes cluster
+  # kubeconfig save` expects). CLUSTER_CONTEXT is the kubeconfig CONTEXT name that
+  # doctl generates from it (do-<region>-<cluster-name>) and what
+  # `kubectl config use-context` expects. These are DIFFERENT strings and must not
+  # be conflated: passing the context name to `kubeconfig save` fails with
+  # "no cluster goes by the name ...".
+  CLUSTER_NAME: ${{ vars.CLUSTER_NAME || 'redducklabs-cluster' }}
   CLUSTER_CONTEXT: ${{ vars.CLUSTER_CONTEXT || 'do-sfo3-redducklabs-cluster' }}
   RELEASE_NAME: ${{ vars.RELEASE_NAME || 'redducklabs-runners' }}
   RUNNER_SCALE_SET_NAME: ${{ vars.RUNNER_SCALE_SET_NAME || 'redducklabs-runners' }}
@@ -183,11 +190,13 @@ jobs:
             fi
           done
           
-          # Configure kubectl with retry logic
-          echo "Configuring kubectl for cluster ${CLUSTER_CONTEXT}..."
+          # Configure kubectl with retry logic.
+          # `kubeconfig save` takes the cluster NAME; `use-context` takes the
+          # generated CONTEXT name (do-<region>-<cluster-name>) — these differ.
+          echo "Configuring kubectl for cluster ${CLUSTER_NAME} (context ${CLUSTER_CONTEXT})..."
           for attempt in 1 2 3; do
             echo "Attempt ${attempt}/3: Configuring kubectl..."
-            if doctl kubernetes cluster kubeconfig save "${CLUSTER_CONTEXT}"; then
+            if doctl kubernetes cluster kubeconfig save "${CLUSTER_NAME}"; then
               kubectl config use-context "${CLUSTER_CONTEXT}"
               echo "✅ Kubernetes access configured"
               break

--- a/.github/workflows/emergency-stop.yml
+++ b/.github/workflows/emergency-stop.yml
@@ -19,6 +19,11 @@ on:
         type: string
 
 env:
+  # CLUSTER_NAME = DO cluster NAME for `doctl ... kubeconfig save`; CLUSTER_CONTEXT
+  # = the generated kubeconfig context (do-<region>-<name>) for `use-context`.
+  # They are different strings — see deploy-runners.yml for the full note.
+  # (Critical here: emergency-stop must reach the cluster reliably.)
+  CLUSTER_NAME: ${{ vars.CLUSTER_NAME || 'redducklabs-cluster' }}
   CLUSTER_CONTEXT: ${{ vars.CLUSTER_CONTEXT || 'do-sfo3-redducklabs-cluster' }}
   RELEASE_NAME: ${{ vars.RELEASE_NAME || 'redducklabs-runners' }}
 
@@ -122,11 +127,12 @@ jobs:
             fi
           done
           
-          # Configure kubectl with retry logic
-          echo "Configuring kubectl for cluster ${CLUSTER_CONTEXT}..."
+          # Configure kubectl with retry logic.
+          # kubeconfig save takes the cluster NAME; use-context takes the context.
+          echo "Configuring kubectl for cluster ${CLUSTER_NAME} (context ${CLUSTER_CONTEXT})..."
           for attempt in 1 2 3; do
             echo "Attempt ${attempt}/3: Configuring kubectl..."
-            if doctl kubernetes cluster kubeconfig save "${CLUSTER_CONTEXT}"; then
+            if doctl kubernetes cluster kubeconfig save "${CLUSTER_NAME}"; then
               kubectl config use-context "${CLUSTER_CONTEXT}"
               echo "✅ Kubernetes access configured"
               break

--- a/.github/workflows/scale-runners.yml
+++ b/.github/workflows/scale-runners.yml
@@ -30,6 +30,10 @@ on:
         type: string
 
 env:
+  # CLUSTER_NAME = DO cluster NAME for `doctl ... kubeconfig save`; CLUSTER_CONTEXT
+  # = the generated kubeconfig context (do-<region>-<name>) for `use-context`.
+  # They are different strings — see deploy-runners.yml for the full note.
+  CLUSTER_NAME: ${{ vars.CLUSTER_NAME || 'redducklabs-cluster' }}
   CLUSTER_CONTEXT: ${{ vars.CLUSTER_CONTEXT || 'do-sfo3-redducklabs-cluster' }}
   RELEASE_NAME: ${{ vars.RELEASE_NAME || 'redducklabs-runners' }}
 
@@ -163,11 +167,12 @@ jobs:
             fi
           done
           
-          # Configure kubectl with retry logic
-          echo "Configuring kubectl for cluster ${CLUSTER_CONTEXT}..."
+          # Configure kubectl with retry logic.
+          # kubeconfig save takes the cluster NAME; use-context takes the context.
+          echo "Configuring kubectl for cluster ${CLUSTER_NAME} (context ${CLUSTER_CONTEXT})..."
           for attempt in 1 2 3; do
             echo "Attempt ${attempt}/3: Configuring kubectl..."
-            if doctl kubernetes cluster kubeconfig save "${CLUSTER_CONTEXT}"; then
+            if doctl kubernetes cluster kubeconfig save "${CLUSTER_NAME}"; then
               kubectl config use-context "${CLUSTER_CONTEXT}"
               echo "✅ Kubernetes access configured"
               break

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -90,8 +90,10 @@ If you prefer to deploy from your local machine:
    # List available clusters
    doctl kubernetes cluster list
    
-   # Get credentials for Red Duck Labs cluster
-   doctl kubernetes cluster kubeconfig save do-sfo3-redducklabs-cluster
+   # Get credentials for Red Duck Labs cluster.
+   # NOTE: pass the cluster NAME (redducklabs-cluster), not the context name.
+   # doctl creates/selects the context do-sfo3-redducklabs-cluster from it.
+   doctl kubernetes cluster kubeconfig save redducklabs-cluster
    ```
 
 3. **Verify access**:
@@ -421,7 +423,9 @@ kubectl create secret generic runner-config \
    ```bash
    # Re-authenticate with DigitalOcean
    doctl auth init
-   doctl kubernetes cluster kubeconfig save do-sfo3-redducklabs-cluster
+   # Pass the cluster NAME (not the context); doctl derives the
+   # do-sfo3-redducklabs-cluster context from it.
+   doctl kubernetes cluster kubeconfig save redducklabs-cluster
    ```
 
 2. **Image Pull Errors**


### PR DESCRIPTION
## Summary

Fix a `doctl kubernetes cluster kubeconfig save` argument bug that aborted the DigitalOcean cluster-access step. It affected **three** workflows that all roll/scale/stop the ARC fleet: `deploy-runners.yml`, `scale-runners.yml`, and `emergency-stop.yml`.

### Root cause

Each ran:

```bash
doctl kubernetes cluster kubeconfig save "${CLUSTER_CONTEXT}"   # CLUSTER_CONTEXT = do-sfo3-redducklabs-cluster
kubectl config use-context "${CLUSTER_CONTEXT}"
```

`doctl ... kubeconfig save` expects the **cluster name**, but was given the kubeconfig **context name**. doctl validated the token then failed with:

```
Error: no cluster goes by the name "do-sfo3-redducklabs-cluster"
```

aborting **before any cluster mutation**. The cluster's real name is `redducklabs-cluster` (already the repo variable `CLUSTER_NAME`); doctl derives the context `do-sfo3-redducklabs-cluster` from it. Observed live in `deploy-runners.yml` dispatch run 27028259227.

### Fix

In `deploy-runners.yml`, `scale-runners.yml`, and `emergency-stop.yml`:
- Add `CLUSTER_NAME` to the job `env` (`vars.CLUSTER_NAME || 'redducklabs-cluster'`).
- Pass `CLUSTER_NAME` to `doctl ... kubeconfig save`; keep `CLUSTER_CONTEXT` for `kubectl config use-context`.
- Inline comments documenting the name-vs-context distinction.

This matches the **already-correct** pattern in `runner-status.yml` (which uses `CLUSTER_NAME` for `kubeconfig save`).

Also fix `docs/SETUP.md`, which documented `kubeconfig save do-sfo3-redducklabs-cluster` (context name) in two places → corrected to `redducklabs-cluster`. SETUP.md's `CLUSTER_CONTEXT=do-sfo3-redducklabs-cluster` line is correct (it's the context) and left as-is.

`deploy/deploy.sh` is intentionally untouched: it only calls `use-context` against an operator's pre-saved kubeconfig and never runs `kubeconfig save`.

## Verification

- Surfaced by a real `deploy-runners.yml` dispatch (run 27028259227) failing exactly here; fleet **not** modified (failure preceded any helm/kubectl mutation).
- All three workflow YAMLs validated locally (PyYAML).
- Repo-wide `grep` confirms every `kubeconfig save` now uses the cluster name; `runner-status.yml` already did.
- Authoritative proof: the next `deploy-runners.yml` dispatch reaching the cluster and completing the helm upgrade.

## Context

Unblocks rolling the ARC fleet onto the new runner image (redducklabs/redducklabs-runners#15, merged), which unblocks redducklabs/aurolegal.ai#895. Part of redducklabs/aurolegal.ai#820.
