### PR TITLE
ci: move buildx layer cache to GHCR + split PR/main build jobs (#17)

### DIFF
--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -13,7 +13,7 @@ on:
         type: boolean
         required: false
         default: false
-  
+
   # Automatic trigger on changes to Docker files
   push:
     branches:
@@ -40,21 +40,45 @@ on:
       - 'test/verify-aws-key-expiry.sh'
       - '.trivyignore'
 
+# Default (job-level blocks below tighten further per job).
+permissions:
+  contents: read
+
 env:
   REGISTRY: registry.digitalocean.com
   REPOSITORY: redducklabs/github-runner
+  # Buildx layer cache lives in GHCR (type=registry), off the 10 GB Actions
+  # cache limit. PRIVATE package — fork PRs are expected cache misses (a public
+  # package would expose the full runner build layers for marginal speedup).
+  BUILDCACHE_RUNNER: ghcr.io/redducklabs/github-runner-buildcache:runner
+
+# ===========================================================================
+# Least privilege by JOB CONSTRUCTION (not editable-YAML conditionals): the
+# PR/main privilege split is structural — separate jobs with separate
+# `permissions:` blocks. The PR-validate job is `packages: read` (cache read
+# only), loads the image locally for the smoke/CVE/Trivy gates, and never
+# pushes to the DO registry or writes the cache. The main-publish job holds
+# `packages: write`, logs in to DO, pushes, and writes the GHCR cache.
+#
+#   VALIDATE event = pull_request  -> build-runner-pr
+#   PUBLISH event  = push to main, or workflow_dispatch  -> build-runner-main
+# ===========================================================================
 
 jobs:
-  build-and-push:
+  # ---------------------------------------------------------------------------
+  # PR validate — load locally, run gates, no DO push, read-only cache.
+  # Fork PRs get a read-only token: GHCR login + cache read are gated to
+  # same-repo, so forks build cold (cache miss) without failing.
+  # ---------------------------------------------------------------------------
+  build-runner-pr:
+    name: Build Runner (validate)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read           # read the private GHCR buildx cache (same-repo)
       pull-requests: write     # PR comment (same-repo only; no-op on forks)
-      security-events: write   # Trivy SARIF upload (push and same-repo PRs)
-    outputs:
-      # Primary tag actually produced for this event; consumed by security-scan
-      # so it verifies/scans the image just built, not a stale ':latest'.
-      image_ref: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ steps.meta.outputs.version }}
+      security-events: write   # Trivy SARIF upload (same-repo PRs)
 
     steps:
       - name: Checkout repository
@@ -66,46 +90,30 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-
-      - name: Log in to DigitalOcean Container Registry
-        if: github.event_name != 'pull_request'
-        run: |
-          echo "🔐 Authenticating with DigitalOcean Container Registry..."
-          echo "🔧 Working around corrupted doctl binary by using docker login directly..."
-          
-          # Use docker login directly with DO token
-          # DigitalOcean registry accepts the token as both username and password
-          echo "${{ secrets.DO_TOKEN }}" | docker login ${{ env.REGISTRY }} --username ${{ secrets.DO_TOKEN }} --password-stdin
-          
-          echo "✅ Successfully authenticated with DigitalOcean Container Registry"
-      
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
+      - name: Log in to GHCR (buildx cache)
+        # Same-repo only: fork PRs get a read-only token with no access to the
+        # private cache package — they skip login and build cold.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@v3
         with:
-          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
-      
-      - name: Build and push Docker image
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build runner image (validate, load locally)
         uses: docker/build-push-action@v5
         with:
           context: ./docker
           file: ./docker/Dockerfile.custom-runner
-          push: ${{ github.event_name != 'pull_request' }}
-          load: ${{ github.event_name == 'pull_request' }}
-          tags: ${{ github.event_name == 'pull_request' && 'rdl-runner:pr' || steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          push: false
+          load: true
+          tags: rdl-runner:pr
+          # Read-only cache; only same-repo PRs can reach the private package.
+          cache-from: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('type=registry,ref={0}', env.BUILDCACHE_RUNNER) || '' }}
           no-cache: ${{ github.event.inputs.force_rebuild == 'true' }}
           platforms: linux/amd64
 
       - name: Smoke test PR image
-        if: github.event_name == 'pull_request'
         run: |
           set -e
           IMG=rdl-runner:pr
@@ -136,7 +144,6 @@ jobs:
           echo "OK Docker CLI floor"
 
       - name: CVE floor gate (PR image, enforcing)
-        if: github.event_name == 'pull_request'
         run: bash test/verify-cve-floor.sh rdl-runner:pr
 
       - name: Trivy scan PR image (report-only)
@@ -144,7 +151,6 @@ jobs:
         # (upstream Go release binaries and the dind base image carry fixed CVEs
         # we cannot remediate). The enforcing security gate is the CVE floor
         # check above; Trivy provides visibility via logs and the SARIF upload.
-        if: github.event_name == 'pull_request'
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: rdl-runner:pr
@@ -158,7 +164,7 @@ jobs:
       - name: Trivy SARIF (reporting, same-repo PRs only)
         # Forks get a read-only token; skip SARIF there so reporting-permission
         # failures never mask or replace the enforcing gate above.
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: rdl-runner:pr
@@ -170,13 +176,97 @@ jobs:
           trivyignores: '.trivyignore'
 
       - name: Upload PR Trivy SARIF
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif
-      
+
+      - name: Comment on PR
+        # Same-repo PRs only: fork PRs get a read-only token and cannot comment.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo, number } = context.issue;
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: number,
+              body: `🐳 Runner image built, smoke-tested, and Trivy-scanned on this PR.\n\nThe image is built and loaded locally as \`rdl-runner:pr\` for verification; it is not pushed to the registry until this PR is merged to \`main\`.`
+            });
+
+  # ---------------------------------------------------------------------------
+  # Main publish — push to the DO registry, write the GHCR cache.
+  # Runs on push-to-main and workflow_dispatch. cache-to writes ONLY on a real
+  # push to main, so manual/force_rebuild dispatches never poison the cache.
+  # ---------------------------------------------------------------------------
+  build-runner-main:
+    name: Build Runner (publish)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write          # write the GHCR buildx cache
+    outputs:
+      # Primary tag actually produced for this event; consumed by security-scan
+      # so it verifies/scans the image just built, not a stale ':latest'.
+      image_ref: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ steps.meta.outputs.version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify AWS signing key not expired (cache-independent)
+        run: bash test/verify-aws-key-expiry.sh docker/aws-cli-public.key
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to DigitalOcean Container Registry
+        run: |
+          echo "🔐 Authenticating with DigitalOcean Container Registry..."
+          echo "🔧 Working around corrupted doctl binary by using docker login directly..."
+
+          # Use docker login directly with DO token
+          # DigitalOcean registry accepts the token as both username and password
+          echo "${{ secrets.DO_TOKEN }}" | docker login ${{ env.REGISTRY }} --username ${{ secrets.DO_TOKEN }} --password-stdin
+
+          echo "✅ Successfully authenticated with DigitalOcean Container Registry"
+
+      - name: Log in to GHCR (buildx cache)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker
+          file: ./docker/Dockerfile.custom-runner
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.BUILDCACHE_RUNNER }}
+          # Write the shared cache ONLY on a real push to main — manual and
+          # force_rebuild dispatches must not poison it.
+          cache-to: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && format('type=registry,ref={0},mode=max', env.BUILDCACHE_RUNNER) || '' }}
+          no-cache: ${{ github.event.inputs.force_rebuild == 'true' }}
+          platforms: linux/amd64
+
       - name: Verify image
-        if: github.event_name != 'pull_request'
         env:
           IMG: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ steps.meta.outputs.version }}
         run: |
@@ -190,19 +280,18 @@ jobs:
           echo "Image verification complete!"
 
       - name: Verify Docker security fix (CVE-2025-54388)
-        if: github.event_name != 'pull_request'
         env:
           IMG: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ steps.meta.outputs.version }}
         run: |
           echo "🔒 Verifying Docker CLI v28.3.3+ for CVE-2025-54388 fix..."
           DOCKER_VERSION=$(docker run --rm "$IMG" docker --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           echo "Docker CLI version in image: $DOCKER_VERSION"
-          
+
           # Verify version is 28.3.3 or higher
           DOCKER_MAJOR=$(echo "$DOCKER_VERSION" | cut -d. -f1)
           DOCKER_MINOR=$(echo "$DOCKER_VERSION" | cut -d. -f2)
           DOCKER_PATCH=$(echo "$DOCKER_VERSION" | cut -d. -f3)
-          
+
           if [[ $DOCKER_MAJOR -gt 28 ]] || \
              [[ $DOCKER_MAJOR -eq 28 && $DOCKER_MINOR -gt 3 ]] || \
              [[ $DOCKER_MAJOR -eq 28 && $DOCKER_MINOR -eq 3 && $DOCKER_PATCH -ge 3 ]]; then
@@ -212,7 +301,7 @@ jobs:
             echo "Required: v28.3.3 or higher"
             exit 1
           fi
-      
+
       - name: Update deployment values (main branch only)
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
@@ -221,53 +310,39 @@ jobs:
           echo "  cd deploy && ./deploy.sh"
           echo ""
           echo "Built image: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest"
-      
-      - name: Comment on PR
-        # Same-repo PRs only: fork PRs get a read-only token and cannot comment.
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo, number } = context.issue;
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: number,
-              body: `🐳 Runner image built, smoke-tested, and Trivy-scanned on this PR.\n\nThe image is built and loaded locally as \`rdl-runner:pr\` for verification; it is not pushed to the registry until this PR is merged to \`main\`.`
-            });
 
   security-scan:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
-    needs: build-and-push
+    needs: build-runner-main
     permissions:
       contents: read
       security-events: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Authenticate with DigitalOcean Registry (for Trivy)
         run: |
           echo "🔐 Authenticating with registry for Trivy scan..."
           echo "🔧 Working around corrupted doctl binary by using docker login directly..."
-          
+
           # Use docker login directly with DO token
           # DigitalOcean registry accepts the token as both username and password
           echo "${{ secrets.DO_TOKEN }}" | docker login ${{ env.REGISTRY }} --username ${{ secrets.DO_TOKEN }} --password-stdin
-          
+
           echo "✅ Successfully authenticated with DigitalOcean Container Registry for Trivy"
-      
+
       - name: CVE floor gate (pushed image, enforcing)
-        run: bash test/verify-cve-floor.sh "${{ needs.build-and-push.outputs.image_ref }}"
+        run: bash test/verify-cve-floor.sh "${{ needs.build-runner-main.outputs.image_ref }}"
 
       - name: Run Trivy vulnerability scanner (report-only)
         # Report-only (see PR job): the enforcing gate is the CVE floor check
         # above. Trivy provides visibility via logs and the SARIF upload.
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: ${{ needs.build-and-push.outputs.image_ref }}
+          image-ref: ${{ needs.build-runner-main.outputs.image_ref }}
           format: table
           exit-code: '0'
           severity: 'CRITICAL,HIGH'
@@ -278,7 +353,7 @@ jobs:
       - name: Run Trivy vulnerability scanner (SARIF report)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: ${{ needs.build-and-push.outputs.image_ref }}
+          image-ref: ${{ needs.build-runner-main.outputs.image_ref }}
           format: sarif
           output: trivy-results.sarif
           severity: 'CRITICAL,HIGH'
@@ -287,10 +362,9 @@ jobs:
           trivyignores: '.trivyignore'
 
       - name: Verify image tools and meaningful versions
-        if: github.event_name != 'pull_request'
         run: |
           echo "🔍 Verifying pushed image tools..."
-          IMG=${{ needs.build-and-push.outputs.image_ref }}
+          IMG=${{ needs.build-runner-main.outputs.image_ref }}
 
           # Check final image size
           IMAGE_SIZE=$(docker images "$IMG" --format "{{.Size}}" | tail -n1)
@@ -319,13 +393,13 @@ jobs:
           # import weasyprint); optional HarfBuzz subset lib omitted by design.
           docker run --rm "$IMG" python3 -c 'import ctypes; [ctypes.CDLL(n) for n in ("libpango-1.0.so.0","libpangoft2-1.0.so.0","libharfbuzz.so.0","libfontconfig.so.1","libcairo.so.2","libffi.so.8")]; print("WEASYPRINT_LIBS_OK")' | grep -q WEASYPRINT_LIBS_OK
           echo "✅ All tools present and reporting real versions"
-      
+
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: trivy-results.sarif
-          
+
       - name: Security scan summary
         if: always()
         run: |

--- a/.github/workflows/prune-buildcache.yml
+++ b/.github/workflows/prune-buildcache.yml
@@ -12,6 +12,18 @@ name: Prune Build Cache
 # on the package: Org → Packages → github-runner-buildcache → Settings → Manage
 # Actions access → add this repository with role Admin. Otherwise scheduled
 # prunes fail and storage grows unbounded.
+#
+# NOTE — bounded, self-healing cache-invalidation risk: deleting untagged
+# container versions can (in the multi-arch image-index case) remove a child
+# manifest still referenced by the tagged `:runner` cache, leaving the tag
+# present but un-importable. Here the blast radius is only a COLD rebuild (the
+# next push to main repopulates the cache), never image loss — this package
+# holds ONLY buildx cache, and the runner image builds a single platform
+# (linux/amd64), so the cache is a single manifest rather than an index with
+# untagged children. `min-versions-to-keep: 5` further protects the most
+# recently pushed untagged manifests. If cold builds are observed right after a
+# prune, switch the delete step to age-based `gh api` deletion (only versions
+# older than the cache rewrite cadence).
 
 on:
   schedule:

--- a/.github/workflows/prune-buildcache.yml
+++ b/.github/workflows/prune-buildcache.yml
@@ -1,0 +1,64 @@
+name: Prune Build Cache
+
+# GHCR has no ECR-style lifecycle policy. Overwriting the buildx cache tag
+# leaves the previous manifest as an UNTAGGED GHCR version; with mode=max +
+# frequent main builds these accumulate in GitHub Packages storage. This
+# workflow prunes the untagged versions (keeping the last few for safety).
+#
+# IMPORTANT — package access requirement: deleting org package versions with the
+# default GITHUB_TOKEN requires the repository to have *Admin* access to the
+# package (token `packages: write` is necessary but NOT sufficient). After the
+# first `main` build publishes `github-runner-buildcache`, grant this repo Admin
+# on the package: Org → Packages → github-runner-buildcache → Settings → Manage
+# Actions access → add this repository with role Admin. Otherwise scheduled
+# prunes fail and storage grows unbounded.
+
+on:
+  schedule:
+    # Weekly real prune (Sundays 04:00 UTC).
+    - cron: "0 4 * * 0"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List untagged candidates only; do NOT delete."
+        type: boolean
+        default: true
+
+permissions:
+  packages: write
+
+concurrency:
+  group: prune-buildcache
+  cancel-in-progress: false
+
+jobs:
+  # The delete-package-versions action has no dry-run mode, so dry-run is a
+  # SEPARATE list-only step that never calls the action.
+  list:
+    name: List untagged cache versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: List untagged versions (candidates for deletion)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "Untagged versions of ghcr.io/redducklabs/github-runner-buildcache:"
+          gh api "/orgs/redducklabs/packages/container/github-runner-buildcache/versions" \
+            --paginate \
+            --jq '.[] | select(.metadata.container.tags == []) | {id, created_at, name}'
+
+  prune:
+    name: Delete untagged cache versions
+    needs: list
+    # Deletes ONLY on the weekly schedule or an explicit dry_run=false dispatch.
+    if: github.event_name == 'schedule' || github.event.inputs.dry_run == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete untagged versions (keep last 5)
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: github-runner-buildcache
+          package-type: container
+          delete-only-untagged-versions: "true"
+          min-versions-to-keep: "5"


### PR DESCRIPTION
## Summary

Moves the **runner image's buildx layer cache** from the GitHub Actions cache
(`type=gha`) to **GHCR** (`type=registry`), taking it off the 10 GB per-repo
Actions-cache ceiling (~8.45/10 GB, mostly `buildkit-blob-*`). The image still
**pushes to the DigitalOcean registry exactly as today** — only the *cache*
moves. Implements **Part B** of the Codex-approved spec (mirrors aurolegal
Part A, redducklabs/aurolegal.ai#900).

## What changed

- **Split `build-and-push` into two jobs (least privilege by construction):**
  - `build-runner-pr` (`if: pull_request`) — `packages: read`, builds with
    `load: true` to `rdl-runner:pr`, runs the smoke test + CVE-floor gate +
    Trivy report/SARIF + PR comment, `cache-from` GHCR only. **No DO push, no
    `packages: write`, no cache write.**
  - `build-runner-main` (`if: != pull_request`) — `packages: write`, DO login +
    push, `cache-to` GHCR. `security-scan` now `needs: build-runner-main`.
- **Private cache package** `ghcr.io/redducklabs/github-runner-buildcache:runner`.
  **Fork PRs are expected cache misses**: GHCR login and `cache-from` are gated
  to `github.event.pull_request.head.repo.full_name == github.repository`, so
  fork PRs (read-only token) build cold without failing. A public package would
  expose the full runner build layers — kept private deliberately.
- **`cache-to` writes only on a real push to `main`** — manual / `force_rebuild`
  dispatches never poison the shared cache.
- **New `prune-buildcache.yml`** — weekly untagged prune (keep last 5), with a
  real list-only `dry_run` path.

The CVE-floor gate, smoke tests (incl. the WeasyPrint `ctypes` check), Trivy
report/SARIF behavior, and `security-scan` are unchanged — just redistributed.

## Validation

- Both workflows parse; job permissions verified (`build-runner-pr` has no
  `packages: write`/DO access; `build-runner-main` holds the writes).
- This PR edits `build-runner-image.yml`, which is in its own path filter, so
  the PR run exercises `build-runner-pr` for real (cold cache — the GHCR package
  doesn't exist until the first `main` build; the cold miss is non-fatal).

## ⚠️ Post-merge manual step (required)

GHCR `GITHUB_TOKEN` deletes need the repo to have **Admin** access to the
package (token scope alone is not sufficient). After the **first `main` build**
publishes `github-runner-buildcache`: **Org → Packages → github-runner-buildcache
→ Settings → Manage Actions access → add this repo with role _Admin_.** Otherwise
the scheduled prune fails and storage grows unbounded.

## Notes

- Related: #14 (in-cluster base-image pull-through mirror) is a **different
  mechanism** — not broadened here.

Closes #17
