### PR TITLE
feat: add Playwright Chromium system libraries to the runner image (#19)

### DIFF
--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -137,6 +137,14 @@ jobs:
           # otherwise. These mirror the consumer app's production image; the
           # optional HarfBuzz subset lib (allow_fail in WeasyPrint) is omitted.
           docker run --rm "$IMG" python3 -c 'import ctypes; [ctypes.CDLL(n) for n in ("libpango-1.0.so.0","libpangoft2-1.0.so.0","libharfbuzz.so.0","libfontconfig.so.1","libcairo.so.2","libffi.so.8")]; print("WEASYPRINT_LIBS_OK")' | grep -q WEASYPRINT_LIBS_OK
+          # Chromium runtime libs Playwright dlopen()s at browser launch. The
+          # consumer E2E job runs `playwright install chromium` (NO --with-deps)
+          # on a non-root, no-new-privileges fleet pod that cannot apt-install
+          # them, so they must already be in this image (added via Playwright
+          # install-deps). SONAMEs are distro-independent (unaffected by noble's
+          # t64 package renames); the real headless launch is exercised
+          # end-to-end by the consumer's test-e2e job on the fleet.
+          docker run --rm "$IMG" python3 -c 'import ctypes; [ctypes.CDLL(n) for n in ("libnss3.so","libnspr4.so","libatk-1.0.so.0","libatk-bridge-2.0.so.0","libatspi.so.0","libcups.so.2","libdrm.so.2","libdbus-1.so.3","libxkbcommon.so.0","libxcb.so.1","libXcomposite.so.1","libXdamage.so.1","libXfixes.so.3","libXrandr.so.2","libgbm.so.1","libasound.so.2")]; print("CHROMIUM_LIBS_OK")' | grep -q CHROMIUM_LIBS_OK
           DV=$(docker run --rm "$IMG" docker --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           echo "Docker CLI: $DV"
           LOW=$(printf '%s\n28.3.3\n' "$DV" | sort -V | head -1)
@@ -392,6 +400,10 @@ jobs:
           # WeasyPrint's hard (import-time) native libs (consumer CI jobs
           # import weasyprint); optional HarfBuzz subset lib omitted by design.
           docker run --rm "$IMG" python3 -c 'import ctypes; [ctypes.CDLL(n) for n in ("libpango-1.0.so.0","libpangoft2-1.0.so.0","libharfbuzz.so.0","libfontconfig.so.1","libcairo.so.2","libffi.so.8")]; print("WEASYPRINT_LIBS_OK")' | grep -q WEASYPRINT_LIBS_OK
+          # Chromium runtime libs for the consumer Playwright E2E job (installed
+          # via Playwright install-deps; consumer runs `playwright install
+          # chromium` without --with-deps on a no-new-privileges fleet pod).
+          docker run --rm "$IMG" python3 -c 'import ctypes; [ctypes.CDLL(n) for n in ("libnss3.so","libnspr4.so","libatk-1.0.so.0","libatk-bridge-2.0.so.0","libatspi.so.0","libcups.so.2","libdrm.so.2","libdbus-1.so.3","libxkbcommon.so.0","libxcb.so.1","libXcomposite.so.1","libXdamage.so.1","libXfixes.so.3","libXrandr.so.2","libgbm.so.1","libasound.so.2")]; print("CHROMIUM_LIBS_OK")' | grep -q CHROMIUM_LIBS_OK
           echo "✅ All tools present and reporting real versions"
 
       - name: Upload Trivy scan results to GitHub Security tab

--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ docker push registry.digitalocean.com/redducklabs/github-runner:latest
 - WeasyPrint native libs (libpango, libpangoft2, libharfbuzz, libfontconfig,
   libcairo2, libffi8) so consumer CI jobs that `import weasyprint` (PDF
   rendering) can load them via ctypes
+- Playwright Chromium system libraries (libnss3, libnspr4, libatk*, libcups,
+  libgbm, libasound, libxkbcommon, the libX* set, …) installed via Playwright
+  `install-deps` so consumer E2E jobs can `playwright install chromium`
+  (without `--with-deps`) and launch headless Chromium — the non-root,
+  no-new-privileges runner pod cannot `sudo apt-get` them at job time. The
+  browser binary itself is downloaded per-run by the consumer, matching its own
+  `@playwright/test` version.
 
 ### Infrastructure Tools
 - Terraform 1.15.5
@@ -171,8 +178,11 @@ CLI/Compose-plugin and GitHub CLI **float** (key-verified; Docker CLI has a smok
 floor of 28.3.3). Ubuntu-archive packages (`postgresql-client`, `redis-tools`,
 `bc`, `libmagic1`, `gettext-base`, `libpq-dev`, the WeasyPrint native libs
 `libpango-1.0-0`/`libpangoft2-1.0-0`/`libharfbuzz0b`/`libfontconfig1`/`libcairo2`/`libffi8`,
-base runtime deps) float as distro-managed. Everything else is pinned +
-checksum/GPG-verified.
+the Playwright Chromium libs resolved by `playwright@${PLAYWRIGHT_VERSION}
+install-deps chromium`, base runtime deps) float as distro-managed. The
+Playwright CLI used to resolve that apt list is version-pinned (`PLAYWRIGHT_VERSION`,
+tracking the consumer's `@playwright/test` minor) but not SHA-pinned, like the
+`pnpm`/`pip` package installs. Everything else is pinned + checksum/GPG-verified.
 
 **AWS CLI signing key rotation**: the AWS CLI v2 signing key (fingerprint
 `A6310ACC4672475C`, full `FB5D B77F D5C1 18B8 0511 ADA8 A631 0ACC 4672 475C`) is

--- a/docker/Dockerfile.custom-runner
+++ b/docker/Dockerfile.custom-runner
@@ -40,6 +40,11 @@ ARG PYTHON_TARBALL_SHA256=928d08ecda5bbf4d8851c5872e363dd9c9be938fdb90f525b6f36a
 ARG NODE_VERSION=22.22.3
 ARG NODE_SHA256=c7a10d6816da8eaaa7534dd73c71c6e2b2c391dbbf845e364902d156615dd1b8
 ARG ACTIONS_RUNNER_BASE=ghcr.io/actions/actions-runner:2.334.0
+# Playwright minor used only to resolve Chromium's apt system-dep list at build
+# (install-deps). The consumer downloads its own browser binary at job time, so
+# this need only track the consumer's @playwright/test MINOR; the dep set is
+# stable across patches. Version-pinned (not SHA), like pnpm/pip in this image.
+ARG PLAYWRIGHT_VERSION=1.60.0
 
 # Stage 1: Go builder - build ONLY kubeconform and kubesec from source with a
 # current Go toolchain. Their upstream release binaries ship below this image's
@@ -117,6 +122,7 @@ ARG BUILDX_SHA256
 ARG UV_VERSION
 ARG UV_SHA256
 ARG AWSCLI_VERSION
+ARG PLAYWRIGHT_VERSION
 
 # Switch to root for installation
 USER root
@@ -353,6 +359,28 @@ RUN set -eux && \
     cp /usr/local/bin/docker-buildx /usr/local/lib/docker/cli-plugins/docker-buildx && \
     rm -f /tmp/docker-buildx && \
     docker buildx version
+
+# Playwright Chromium runtime system libraries. The consumer's E2E job
+# (aurolegal.ai .github/workflows/ci.yml `test-e2e`) runs Playwright headless
+# Chromium on this fleet. The browser BINARY is downloaded per-run by the
+# consumer (`playwright install chromium`) so it always matches that repo's
+# @playwright/test version — but Chromium's ~20 shared libraries (libnss3,
+# libnspr4, libatk*, libcups, libgbm, libasound, libxkbcommon, the libX* set,
+# …) must be present in THIS image. The consumer job runs as the non-root
+# `runner` user under a `no-new-privileges` pod, so Playwright's
+# `install --with-deps` (which `sudo apt-get` installs them) cannot escalate to
+# root and fails. We install the deps here as root via Playwright's own
+# `install-deps`, which resolves the correct Ubuntu-noble package names
+# (including the t64-renamed libatk/libcups/libasound), letting the consumer
+# drop `--with-deps`. `npx --yes` runs the pinned Playwright CLI without a
+# global install; the npm/npx caches are scrubbed afterwards so nothing but the
+# apt libraries ships.
+RUN set -eux && \
+    apt-get update && \
+    npx --yes playwright@${PLAYWRIGHT_VERSION} install-deps chromium && \
+    npm cache clean --force && \
+    rm -rf /var/lib/apt/lists/* /root/.npm /root/.cache /tmp/* && \
+    echo "Playwright Chromium system dependencies installed (browser downloaded per-run by consumer)"
 
 # Final cleanup - remove installation files and caches (keep clean Go runtime)
 RUN apt-get clean && \

--- a/test/verify-tools.sh
+++ b/test/verify-tools.sh
@@ -78,6 +78,18 @@ print('✓ WeasyPrint native libraries loadable')
 "
 echo ""
 
+# Test Chromium runtime libraries (the consumer Playwright E2E job downloads the
+# browser binary per-run but relies on these shared objects being baked into the
+# image — the no-new-privileges fleet pod cannot apt-install them at job time).
+echo -e "${BLUE}Testing Chromium runtime libraries:${NC}"
+kubectl exec -n arc-runners "$RUNNER_POD" -c runner -- python3 -c "
+import ctypes
+for so in ('libnss3.so', 'libnspr4.so', 'libatk-1.0.so.0', 'libatk-bridge-2.0.so.0', 'libatspi.so.0', 'libcups.so.2', 'libdrm.so.2', 'libdbus-1.so.3', 'libxkbcommon.so.0', 'libxcb.so.1', 'libXcomposite.so.1', 'libXdamage.so.1', 'libXfixes.so.3', 'libXrandr.so.2', 'libgbm.so.1', 'libasound.so.2'):
+    ctypes.CDLL(so)
+print('✓ Chromium runtime libraries loadable')
+"
+echo ""
+
 # Test security tools
 test_tool "kubeconform 0.7.0" "kubeconform -v"
 test_tool "kubesec 2.14.2" "kubesec version"


### PR DESCRIPTION
## Summary

Adds Playwright's Chromium system libraries to the custom runner image so the **aurolegal.ai E2E job** (`ci.yml` `test-e2e`) can run on this fleet (aurolegal #820, Phase 4).

On a hosted `ubuntu-latest` runner that job uses `playwright install --with-deps chromium`, which `sudo apt-get`s Chromium's OS libraries. The fleet runner pod runs as the non-root `runner` user under `no-new-privileges`, so `sudo` cannot escalate and the install fails:

```
Switching to root user to install dependencies...
sudo: The "no new privileges" flag is set, which prevents sudo from running as root.
Failed to install browsers
```

The image had the WeasyPrint native libs (#15) but **none** of Chromium's (`libnss3`, `libnspr4`, `libatk*`, `libcups`, `libgbm`, `libasound`, `libxkbcommon`, the `libX*` set, …).

## Approach

- **`docker/Dockerfile.custom-runner`** — install Chromium's system deps as root via Playwright's own `install-deps`, which resolves the correct **Ubuntu-noble** package names (incl. the t64-renamed `libatk*`/`libcups`/`libasound`). This is list-free and self-maintaining — no hand-maintained per-distro package list. The browser **binary** is still downloaded per-run by the consumer (`playwright install chromium`, no `--with-deps`), so it always matches that repo's `@playwright/test` version and stays decoupled from this image.
- **`PLAYWRIGHT_VERSION`** centralized ARG (top manifest + final-stage re-declaration), pinned to the consumer's minor (`1.60.0`). Version-pinned (not SHA), consistent with the existing `pnpm`/`pip` pattern; only used to resolve the apt dep list at build.
- **Smoke** — added a ctypes SONAME load check for the Chromium libs at the three sites that already check the WeasyPrint libs (PR build smoke, main verify, `test/verify-tools.sh`), mirroring that pattern. SONAMEs are distro-independent (unaffected by the noble t64 renames). The real headless launch is exercised end-to-end by the consumer's `test-e2e` job on the fleet after this image deploys.
- **`README.md`** — documented the new libs + the package-pinning-policy note.

## Why install-deps rather than a hardcoded apt list

The noble t64 renames (`libasound2`→`libasound2t64`, `libatk1.0-0`→`libatk1.0-0t64`, `libcups2`→`libcups2t64`, …) make a hand-maintained list error-prone — one wrong name fails the build, and a missed one silently underinstalls. Playwright maintains the correct per-distro set, so delegating to `install-deps` is the robust choice. `pnpm`/`pip` already establish version-pinned-without-SHA installs in this image.

## Verification

- **Local targeted build** on the exact noble base (`ghcr.io/actions/actions-runner:2.334.0`): `npx playwright@1.60.0 install-deps chromium` installed the deps and the ctypes smoke loaded **all 16 SONAMEs** → `CHROMIUM_LIBS_OK`.
- CI here builds the full image and runs the new PR-build smoke (`CHROMIUM_LIBS_OK`) + CVE floor + Trivy.
- End-to-end: after merge + fleet redeploy, aurolegal PR #905 re-runs `test-e2e` on the fleet (the authoritative headless-Chromium-launch test).

Closes #19
