### PR TITLE
ci: bump JavaScript actions to Node 24 runtime versions

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -67,7 +67,7 @@ runs:
         echo "Cache key: ${CACHE_KEY}"
 
     - name: Cache tools
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: cache-tools
       with:
         path: |

--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -82,26 +82,26 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify AWS signing key not expired (cache-independent)
         run: bash test/verify-aws-key-expiry.sh docker/aws-cli-public.key
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR (buildx cache)
         # Same-repo only: fork PRs get a read-only token with no access to the
         # private cache package — they skip login and build cold.
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build runner image (validate, load locally)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./docker
           file: ./docker/Dockerfile.custom-runner
@@ -192,7 +192,7 @@ jobs:
       - name: Comment on PR
         # Same-repo PRs only: fork PRs get a read-only token and cannot comment.
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { owner, repo, number } = context.issue;
@@ -222,13 +222,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify AWS signing key not expired (cache-independent)
         run: bash test/verify-aws-key-expiry.sh docker/aws-cli-public.key
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to DigitalOcean Container Registry
         run: |
@@ -242,7 +242,7 @@ jobs:
           echo "✅ Successfully authenticated with DigitalOcean Container Registry"
 
       - name: Log in to GHCR (buildx cache)
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -250,7 +250,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}
           tags: |
@@ -260,7 +260,7 @@ jobs:
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./docker
           file: ./docker/Dockerfile.custom-runner
@@ -329,7 +329,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Authenticate with DigitalOcean Registry (for Trivy)
         run: |

--- a/.github/workflows/deploy-runners.yml
+++ b/.github/workflows/deploy-runners.yml
@@ -128,7 +128,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup infrastructure tools
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/emergency-stop.yml
+++ b/.github/workflows/emergency-stop.yml
@@ -95,7 +95,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup infrastructure tools
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/runner-status.yml
+++ b/.github/workflows/runner-status.yml
@@ -84,7 +84,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup infrastructure tools
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/scale-runners.yml
+++ b/.github/workflows/scale-runners.yml
@@ -135,7 +135,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup infrastructure tools
         uses: ./.github/actions/setup-tools


### PR DESCRIPTION
GitHub force-migrates Node 20 actions to Node 24 on **2026-06-16**. This bumps the affected actions to their current Node 24 releases.

| Action | From | To | Runtime |
|---|---|---|---|
| actions/checkout | v4 | v6 | node24 |
| actions/cache | v4 | v5 | node24 |
| actions/github-script | v7 | v9 | node24 |
| docker/setup-buildx-action | v3 | v4 | node24 |
| docker/login-action | v3 | v4 | node24 |
| docker/build-push-action | v5 | v7 | node24 |
| docker/metadata-action | v5 | v6 | node24 |

**Left unchanged (intentionally):**
- `github/codeql-action@v3` — the v3 major already ships Node 24
- `aquasecurity/trivy-action` — composite action, no Node runtime
- `actions/delete-package-versions@v5` — no Node 24 release exists yet; force-migrated at runtime

Usages are all standard (plain checkout; build-push with stock inputs; github-script doing a trivial `issues.createComment`), so no input/behavior changes were needed. Opening as a PR so the `build-runner-image` PR job exercises the bumped build/login/buildx/github-script actions before merge.