### PR TITLE
fix: reserve memory for the Docker daemon and raise runner capacity to 8

### DIFF
--- a/.github/workflows/deploy-cluster-addons.yml
+++ b/.github/workflows/deploy-cluster-addons.yml
@@ -1,0 +1,172 @@
+name: Deploy Cluster Addons
+
+# Deploys cluster addons that the runner platform depends on.
+#
+# Currently: metrics-server, which backs `kubectl top` and therefore all runner
+# memory observability. DOKS does not ship it on this cluster, so without this
+# workflow there is no way to see how much memory a runner or its Docker daemon
+# is using.
+#
+# Configuration lives in deploy/metrics-server-values.yaml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      addon:
+        description: 'Addon to deploy'
+        required: true
+        default: 'metrics-server'
+        type: choice
+        options:
+          - 'metrics-server'
+      metrics_server_chart_version:
+        description: 'metrics-server Helm chart version'
+        required: false
+        default: '3.14.0'
+        type: string
+
+env:
+  CLUSTER_NAME: ${{ vars.CLUSTER_NAME || 'redducklabs-cluster' }}
+  CLUSTER_CONTEXT: ${{ vars.CLUSTER_CONTEXT || 'do-sfo3-redducklabs-cluster' }}
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-addon:
+    name: Deploy ${{ github.event.inputs.addon }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup infrastructure tools
+        uses: ./.github/actions/setup-tools
+        with:
+          install-jq: 'true'
+
+      - name: Validate inputs
+        id: validate
+        run: |
+          echo "🔍 Validating addon inputs..."
+          CHART_VERSION="${{ github.event.inputs.metrics_server_chart_version }}"
+
+          if ! [[ "${CHART_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ Error: chart version must be X.Y.Z"
+            exit 1
+          fi
+
+          echo "chart_version=${CHART_VERSION}" >> $GITHUB_OUTPUT
+          echo "✅ Inputs validated"
+
+      - name: Configure Kubernetes access
+        run: |
+          echo "🔧 Configuring Kubernetes access..."
+
+          if [ -z "${{ secrets.DO_TOKEN }}" ]; then
+            echo "❌ Error: DO_TOKEN secret is not set!"
+            exit 1
+          fi
+
+          for attempt in 1 2 3; do
+            echo "Attempt ${attempt}/3: Configuring doctl..."
+            if doctl auth init --access-token "${{ secrets.DO_TOKEN }}"; then
+              echo "✅ DigitalOcean authentication configured"
+              break
+            elif [ "${attempt}" = "3" ]; then
+              echo "❌ Error: Failed to authenticate with DigitalOcean"
+              exit 1
+            else
+              echo "⚠️ Authentication failed, retrying in 5s..."
+              sleep 5
+            fi
+          done
+
+          # `kubeconfig save` takes the cluster NAME; `use-context` takes the
+          # generated CONTEXT name (do-<region>-<cluster-name>) - these differ.
+          for attempt in 1 2 3; do
+            echo "Attempt ${attempt}/3: Configuring kubectl..."
+            if doctl kubernetes cluster kubeconfig save "${CLUSTER_NAME}"; then
+              kubectl config use-context "${CLUSTER_CONTEXT}"
+              echo "✅ Kubernetes access configured"
+              break
+            elif [ "${attempt}" = "3" ]; then
+              echo "❌ Error: Failed to configure kubectl"
+              exit 1
+            else
+              echo "⚠️ kubectl configuration failed, retrying in 5s..."
+              sleep 5
+            fi
+          done
+
+      - name: Deploy metrics-server
+        if: github.event.inputs.addon == 'metrics-server'
+        run: |
+          echo "📦 Deploying metrics-server..."
+
+          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+          helm repo update metrics-server
+
+          for attempt in 1 2 3; do
+            echo "Attempt ${attempt}/3: Deploying metrics-server..."
+            if helm upgrade --install metrics-server metrics-server/metrics-server \
+              --namespace kube-system \
+              --version "${{ steps.validate.outputs.chart_version }}" \
+              --values deploy/metrics-server-values.yaml \
+              --wait --timeout 300s; then
+              echo "✅ metrics-server deployed"
+              break
+            elif [ "${attempt}" = "3" ]; then
+              echo "❌ Error: Failed to deploy metrics-server"
+              kubectl -n kube-system get pods -l app.kubernetes.io/name=metrics-server || true
+              kubectl -n kube-system logs -l app.kubernetes.io/name=metrics-server --tail=50 || true
+              exit 1
+            else
+              echo "⚠️ Deployment failed, retrying in 10s..."
+              sleep 10
+            fi
+          done
+
+      - name: Verify metrics API
+        if: github.event.inputs.addon == 'metrics-server'
+        run: |
+          echo "🔍 Verifying the metrics API actually serves data..."
+
+          # A Running pod is not proof the APIService is answering. Poll until
+          # `kubectl top` returns real numbers.
+          for attempt in $(seq 1 12); do
+            if kubectl top nodes >/dev/null 2>&1; then
+              echo "✅ Metrics API is serving"
+              echo ""
+              echo "Node usage:"
+              kubectl top nodes
+              echo ""
+              echo "Runner container usage:"
+              kubectl top pods -n arc-runners --containers 2>/dev/null || echo "(no runner pods right now)"
+              exit 0
+            fi
+            echo "Attempt ${attempt}/12: metrics API not ready yet, waiting 10s..."
+            sleep 10
+          done
+
+          echo "❌ Error: metrics API did not become available"
+          kubectl get apiservice v1beta1.metrics.k8s.io -o yaml || true
+          kubectl -n kube-system logs -l app.kubernetes.io/name=metrics-server --tail=50 || true
+          exit 1
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Cluster Addon Deployment"
+            echo ""
+            echo "- **Addon:** \`${{ github.event.inputs.addon }}\`"
+            echo "- **Chart version:** \`${{ steps.validate.outputs.chart_version }}\`"
+            echo "- **Cluster:** \`${{ env.CLUSTER_NAME }}\`"
+            echo ""
+            echo "\`kubectl top nodes\` and \`kubectl top pods -n arc-runners --containers\`"
+            echo "are how you check runner memory headroom. See"
+            echo "\`docs/runbooks/node-pool-sizing.md\`."
+          } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-runners.yml
+++ b/.github/workflows/deploy-runners.yml
@@ -17,7 +17,7 @@ on:
       max_runners:
         description: 'Maximum number of runners'
         required: false
-        default: '6'
+        default: '8'
         type: choice
         options:
           - '1'
@@ -209,6 +209,58 @@ jobs:
             fi
           done
       
+      - name: Check node pool capacity
+        continue-on-error: true
+        run: |
+          echo "📐 Checking node pool capacity against requested runner count..."
+          MAX_RUNNERS="${{ needs.validate-inputs.outputs.max_runners }}"
+          MIN_RUNNERS="${{ needs.validate-inputs.outputs.min_runners }}"
+          POOL_NAME="github-runners-pool-16g"
+
+          # One runner pod is scheduled per node: the pod requests 10Gi of
+          # memory (runner 5Gi + dind 5Gi) against ~13.32Gi of node allocatable,
+          # so two pods cannot share a node. Concurrency is therefore capped by
+          # max_nodes as well as by maxRunners.
+          CLUSTER_ID=$(doctl kubernetes cluster list -o json 2>/dev/null \
+            | jq -r --arg n "${CLUSTER_NAME}" '.[] | select(.name==$n) | .id')
+
+          if [ -z "${CLUSTER_ID}" ] || [ "${CLUSTER_ID}" = "null" ]; then
+            echo "⚠️ Could not resolve cluster '${CLUSTER_NAME}' - skipping capacity check"
+            exit 0
+          fi
+
+          POOL_JSON=$(doctl kubernetes cluster node-pool list "${CLUSTER_ID}" -o json 2>/dev/null \
+            | jq -r --arg p "${POOL_NAME}" '.[] | select(.name==$p)')
+
+          if [ -z "${POOL_JSON}" ]; then
+            echo "⚠️ Node pool '${POOL_NAME}' not found - skipping capacity check"
+            exit 0
+          fi
+
+          POOL_MIN=$(echo "${POOL_JSON}" | jq -r '.min_nodes')
+          POOL_MAX=$(echo "${POOL_JSON}" | jq -r '.max_nodes')
+
+          echo "  Node pool: min_nodes=${POOL_MIN} max_nodes=${POOL_MAX}"
+          echo "  Requested: minRunners=${MIN_RUNNERS} maxRunners=${MAX_RUNNERS}"
+
+          if [ "${MAX_RUNNERS}" -gt "${POOL_MAX}" ]; then
+            echo "⚠️ WARNING: maxRunners (${MAX_RUNNERS}) exceeds pool max_nodes (${POOL_MAX})."
+            echo "   Runners above ${POOL_MAX} will stay Pending indefinitely."
+            echo "   Resize the pool with the 'Node Pool Sizing' workflow."
+            {
+              echo "### ⚠️ Capacity warning"
+              echo ""
+              echo "\`maxRunners=${MAX_RUNNERS}\` exceeds node pool \`max_nodes=${POOL_MAX}\`."
+              echo "One runner pod runs per node, so runners above ${POOL_MAX} will stay Pending."
+              echo "Fix with the **Node Pool Sizing** workflow."
+            } >> $GITHUB_STEP_SUMMARY
+          elif [ "${MIN_RUNNERS}" -gt "${POOL_MIN}" ]; then
+            echo "⚠️ WARNING: minRunners (${MIN_RUNNERS}) exceeds pool min_nodes (${POOL_MIN})."
+            echo "   Warm runners will wait on node provisioning until the pool scales up."
+          else
+            echo "✅ Node pool capacity is sufficient"
+          fi
+
       - name: Create namespace if not exists
         run: |
           echo "📁 Ensuring namespace exists..."

--- a/.github/workflows/node-pool-sizing.yml
+++ b/.github/workflows/node-pool-sizing.yml
@@ -1,0 +1,275 @@
+name: Node Pool Sizing
+
+# Applies the autoscaling bounds of the dedicated GitHub runner node pool.
+#
+# Why this workflow exists: the runner pool's min/max node bounds used to live
+# only in a comment in deploy/dind-values.yaml while the real values were set by
+# hand in the DigitalOcean console. That made half the runner capacity design
+# unreproducible. This workflow makes the bounds a reviewed, repeatable change.
+#
+# The runner scale set places exactly ONE runner pod per node (see the resource
+# sizing note in deploy/dind-values.yaml), so the pool bounds and the scale set
+# bounds must agree:
+#
+#     min_nodes >= minRunners      and      max_nodes >= maxRunners
+#
+# Those assertions are enforced below against deploy/dind-values.yaml, so the
+# committed values file stays the source of truth.
+#
+# See docs/runbooks/node-pool-sizing.md for the operational procedure.
+
+on:
+  workflow_dispatch:
+    inputs:
+      min_nodes:
+        description: 'Minimum nodes in the runner pool (warm capacity, always billed)'
+        required: true
+        default: '2'
+        type: string
+      max_nodes:
+        description: 'Maximum nodes in the runner pool (cost ceiling)'
+        required: true
+        default: '8'
+        type: string
+      pool_name:
+        description: 'Node pool name'
+        required: false
+        default: 'github-runners-pool-16g'
+        type: string
+      apply:
+        description: 'Actually apply the change (unchecked = dry run)'
+        required: false
+        default: false
+        type: boolean
+
+env:
+  CLUSTER_NAME: ${{ vars.CLUSTER_NAME || 'redducklabs-cluster' }}
+
+permissions:
+  contents: read
+
+jobs:
+  size-pool:
+    name: Apply Node Pool Sizing
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup infrastructure tools
+        uses: ./.github/actions/setup-tools
+        with:
+          install-jq: 'true'
+
+      - name: Validate inputs against deploy/dind-values.yaml
+        id: validate
+        run: |
+          echo "🔍 Validating node pool sizing inputs..."
+
+          MIN_NODES="${{ github.event.inputs.min_nodes }}"
+          MAX_NODES="${{ github.event.inputs.max_nodes }}"
+          POOL_NAME="${{ github.event.inputs.pool_name }}"
+
+          if ! [[ "${MIN_NODES}" =~ ^[0-9]+$ ]]; then
+            echo "❌ Error: min_nodes must be a number"
+            exit 1
+          fi
+          if ! [[ "${MAX_NODES}" =~ ^[0-9]+$ ]]; then
+            echo "❌ Error: max_nodes must be a number"
+            exit 1
+          fi
+          if [ "${MIN_NODES}" -lt 1 ]; then
+            echo "❌ Error: min_nodes must be at least 1"
+            echo "   DigitalOcean autoscaling pools cannot scale to zero."
+            exit 1
+          fi
+          if [ "${MIN_NODES}" -gt "${MAX_NODES}" ]; then
+            echo "❌ Error: min_nodes (${MIN_NODES}) cannot exceed max_nodes (${MAX_NODES})"
+            exit 1
+          fi
+          if ! [[ "${POOL_NAME}" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]]; then
+            echo "❌ Error: pool_name must be a valid DNS-1123 label"
+            exit 1
+          fi
+
+          # deploy/dind-values.yaml is the source of truth for runner counts.
+          MIN_RUNNERS=$(grep -E '^minRunners:' deploy/dind-values.yaml | awk '{print $2}')
+          MAX_RUNNERS=$(grep -E '^maxRunners:' deploy/dind-values.yaml | awk '{print $2}')
+
+          if ! [[ "${MIN_RUNNERS}" =~ ^[0-9]+$ ]] || ! [[ "${MAX_RUNNERS}" =~ ^[0-9]+$ ]]; then
+            echo "❌ Error: could not parse minRunners/maxRunners from deploy/dind-values.yaml"
+            exit 1
+          fi
+
+          echo "  deploy/dind-values.yaml: minRunners=${MIN_RUNNERS} maxRunners=${MAX_RUNNERS}"
+          echo "  requested pool bounds:   min_nodes=${MIN_NODES} max_nodes=${MAX_NODES}"
+
+          # One runner pod per node: memory requests (runner 5Gi + dind 5Gi)
+          # exceed half of node allocatable, so two pods cannot share a node.
+          if [ "${MAX_NODES}" -lt "${MAX_RUNNERS}" ]; then
+            echo "❌ Error: max_nodes (${MAX_NODES}) < maxRunners (${MAX_RUNNERS})"
+            echo "   One runner pod is scheduled per node, so ${MAX_RUNNERS} concurrent"
+            echo "   runners require at least ${MAX_RUNNERS} nodes. Raise max_nodes or"
+            echo "   lower maxRunners in deploy/dind-values.yaml first."
+            exit 1
+          fi
+          if [ "${MIN_NODES}" -lt "${MIN_RUNNERS}" ]; then
+            echo "❌ Error: min_nodes (${MIN_NODES}) < minRunners (${MIN_RUNNERS})"
+            echo "   ${MIN_RUNNERS} warm runners require at least ${MIN_RUNNERS} warm nodes,"
+            echo "   otherwise idle runners sit Pending and jobs queue behind node"
+            echo "   provisioning. Raise min_nodes or lower minRunners."
+            exit 1
+          fi
+
+          echo "min_nodes=${MIN_NODES}" >> $GITHUB_OUTPUT
+          echo "max_nodes=${MAX_NODES}" >> $GITHUB_OUTPUT
+          echo "pool_name=${POOL_NAME}" >> $GITHUB_OUTPUT
+          echo "✅ Inputs are consistent with the deployed runner configuration"
+
+      - name: Configure DigitalOcean access
+        run: |
+          echo "🔧 Configuring DigitalOcean access..."
+
+          if [ -z "${{ secrets.DO_TOKEN }}" ]; then
+            echo "❌ Error: DO_TOKEN secret is not set!"
+            exit 1
+          fi
+
+          for attempt in 1 2 3; do
+            echo "Attempt ${attempt}/3: Configuring doctl..."
+            if doctl auth init --access-token "${{ secrets.DO_TOKEN }}"; then
+              echo "✅ DigitalOcean authentication configured"
+              break
+            elif [ "${attempt}" = "3" ]; then
+              echo "❌ Error: Failed to authenticate with DigitalOcean"
+              exit 1
+            else
+              echo "⚠️ Authentication failed, retrying in 5s..."
+              sleep 5
+            fi
+          done
+
+      - name: Resolve cluster and pool
+        id: resolve
+        run: |
+          echo "🔎 Resolving cluster and node pool IDs..."
+          POOL_NAME="${{ steps.validate.outputs.pool_name }}"
+
+          CLUSTER_ID=$(doctl kubernetes cluster list -o json \
+            | jq -r --arg n "${CLUSTER_NAME}" '.[] | select(.name==$n) | .id')
+          if [ -z "${CLUSTER_ID}" ] || [ "${CLUSTER_ID}" = "null" ]; then
+            echo "❌ Error: cluster '${CLUSTER_NAME}' not found"
+            exit 1
+          fi
+
+          POOL_JSON=$(doctl kubernetes cluster node-pool list "${CLUSTER_ID}" -o json \
+            | jq -r --arg p "${POOL_NAME}" '.[] | select(.name==$p)')
+          if [ -z "${POOL_JSON}" ]; then
+            echo "❌ Error: node pool '${POOL_NAME}' not found in cluster '${CLUSTER_NAME}'"
+            exit 1
+          fi
+
+          POOL_ID=$(echo "${POOL_JSON}" | jq -r '.id')
+          CUR_MIN=$(echo "${POOL_JSON}" | jq -r '.min_nodes')
+          CUR_MAX=$(echo "${POOL_JSON}" | jq -r '.max_nodes')
+          CUR_COUNT=$(echo "${POOL_JSON}" | jq -r '.count')
+          CUR_SIZE=$(echo "${POOL_JSON}" | jq -r '.size')
+
+          echo "pool_id=${POOL_ID}" >> $GITHUB_OUTPUT
+          echo "cluster_id=${CLUSTER_ID}" >> $GITHUB_OUTPUT
+          echo "cur_min=${CUR_MIN}" >> $GITHUB_OUTPUT
+          echo "cur_max=${CUR_MAX}" >> $GITHUB_OUTPUT
+          echo "cur_size=${CUR_SIZE}" >> $GITHUB_OUTPUT
+
+          echo "Current pool state:"
+          echo "  size:      ${CUR_SIZE}"
+          echo "  nodes now: ${CUR_COUNT}"
+          echo "  min_nodes: ${CUR_MIN}"
+          echo "  max_nodes: ${CUR_MAX}"
+
+      - name: Apply pool sizing
+        id: apply
+        run: |
+          POOL_ID="${{ steps.resolve.outputs.pool_id }}"
+          CLUSTER_ID="${{ steps.resolve.outputs.cluster_id }}"
+          MIN_NODES="${{ steps.validate.outputs.min_nodes }}"
+          MAX_NODES="${{ steps.validate.outputs.max_nodes }}"
+
+          if [ "${{ github.event.inputs.apply }}" != "true" ]; then
+            echo "🧪 DRY RUN - no changes applied."
+            echo "Would run:"
+            echo "  doctl kubernetes cluster node-pool update ${CLUSTER_ID} ${POOL_ID} \\"
+            echo "    --auto-scale --min-nodes ${MIN_NODES} --max-nodes ${MAX_NODES}"
+            echo "Re-run with 'apply' checked to make the change."
+            exit 0
+          fi
+
+          echo "🚀 Applying node pool sizing..."
+          # --auto-scale is passed explicitly: omitting it on an update can clear
+          # autoscaling and pin the pool to a fixed node count.
+          doctl kubernetes cluster node-pool update "${CLUSTER_ID}" "${POOL_ID}" \
+            --auto-scale --min-nodes "${MIN_NODES}" --max-nodes "${MAX_NODES}"
+
+          echo "✅ Applied"
+
+      - name: Verify pool sizing
+        if: github.event.inputs.apply == 'true'
+        run: |
+          echo "🔍 Verifying applied configuration..."
+          POOL_NAME="${{ steps.validate.outputs.pool_name }}"
+          CLUSTER_ID="${{ steps.resolve.outputs.cluster_id }}"
+          MIN_NODES="${{ steps.validate.outputs.min_nodes }}"
+          MAX_NODES="${{ steps.validate.outputs.max_nodes }}"
+
+          POOL_JSON=$(doctl kubernetes cluster node-pool list "${CLUSTER_ID}" -o json \
+            | jq -r --arg p "${POOL_NAME}" '.[] | select(.name==$p)')
+
+          NEW_MIN=$(echo "${POOL_JSON}" | jq -r '.min_nodes')
+          NEW_MAX=$(echo "${POOL_JSON}" | jq -r '.max_nodes')
+          NEW_AUTO=$(echo "${POOL_JSON}" | jq -r '.auto_scale')
+
+          echo "  auto_scale: ${NEW_AUTO}"
+          echo "  min_nodes:  ${NEW_MIN}"
+          echo "  max_nodes:  ${NEW_MAX}"
+
+          FAILED=0
+          [ "${NEW_AUTO}" = "true" ]        || { echo "❌ auto_scale is not enabled"; FAILED=1; }
+          [ "${NEW_MIN}" = "${MIN_NODES}" ] || { echo "❌ min_nodes is ${NEW_MIN}, expected ${MIN_NODES}"; FAILED=1; }
+          [ "${NEW_MAX}" = "${MAX_NODES}" ] || { echo "❌ max_nodes is ${NEW_MAX}, expected ${MAX_NODES}"; FAILED=1; }
+
+          # Labels and taints must survive the update or runners lose their
+          # dedicated pool and can land on production nodes.
+          LABEL=$(echo "${POOL_JSON}" | jq -r '.labels["node-type"] // "MISSING"')
+          TAINT=$(echo "${POOL_JSON}" | jq -r '[.taints[]? | select(.key=="github-runner")] | length')
+          [ "${LABEL}" = "github-runner" ] || { echo "❌ node-type label lost (got '${LABEL}')"; FAILED=1; }
+          [ "${TAINT}" -ge 1 ]             || { echo "❌ github-runner taint lost"; FAILED=1; }
+
+          if [ "${FAILED}" != "0" ]; then
+            echo "❌ Verification failed"
+            exit 1
+          fi
+          echo "✅ Node pool sizing verified (labels and taints intact)"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Node Pool Sizing"
+            echo ""
+            if [ "${{ github.event.inputs.apply }}" = "true" ]; then
+              echo "**Applied** to pool \`${{ steps.validate.outputs.pool_name }}\`"
+            else
+              echo "**Dry run** - nothing was changed"
+            fi
+            echo ""
+            echo "| | Before | After |"
+            echo "|---|---|---|"
+            echo "| min_nodes | ${{ steps.resolve.outputs.cur_min }} | ${{ steps.validate.outputs.min_nodes }} |"
+            echo "| max_nodes | ${{ steps.resolve.outputs.cur_max }} | ${{ steps.validate.outputs.max_nodes }} |"
+            echo ""
+            echo "Node size: \`${{ steps.resolve.outputs.cur_size }}\`."
+            echo "Cost scales linearly with node count; \`min_nodes\` is the always-billed floor."
+            echo "See \`docs/runbooks/node-pool-sizing.md\`."
+          } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/runner-status.yml
+++ b/.github/workflows/runner-status.yml
@@ -79,10 +79,9 @@ jobs:
   status:
     name: Check Runner Status
     # Runs on ubuntu-latest (like the other ops workflows) rather than the
-    # self-hosted runners: this job uses setup-tools, which installs binaries
-    # via sudo, and the runner pods set allowPrivilegeEscalation: false
-    # (NoNewPrivs) which blocks sudo. Running here also lets status report even
-    # when the runners themselves are unhealthy.
+    # self-hosted runners, so that status can still be reported when the runners
+    # themselves are unhealthy, saturated, or scaled to zero - which is exactly
+    # when you want this workflow to work.
     runs-on: ubuntu-latest
     needs: validate-inputs
     timeout-minutes: 5
@@ -197,8 +196,17 @@ jobs:
             MAX_RUNNERS=$(echo "${VALUES_JSON}" | jq -r '.maxRunners // 0')
             GITHUB_URL=$(echo "${VALUES_JSON}" | jq -r '.githubConfigUrl // "Not configured"')
             RUNNER_NAME=$(echo "${VALUES_JSON}" | jq -r '.runnerScaleSetName // "Not configured"')
-            CONTAINER_MODE=$(echo "${VALUES_JSON}" | jq -r '.containerMode.type // "Not configured"')
-            
+            # containerMode.type is no longer set: the Docker-in-Docker sidecar
+            # is declared explicitly in deploy/dind-values.yaml so it can carry
+            # memory requests/limits, which ARC's built-in dind mode does not
+            # allow. Detect the self-managed sidecar rather than reporting
+            # "Not configured", which would look like Docker was missing.
+            if [ "$(echo "${VALUES_JSON}" | jq -r '[.template.spec.initContainers[]? | select(.name=="dind")] | length')" -gt 0 ]; then
+              CONTAINER_MODE="dind (self-managed sidecar)"
+            else
+              CONTAINER_MODE=$(echo "${VALUES_JSON}" | jq -r '.containerMode.type // "Not configured"')
+            fi
+
             # Validate numeric values
             if ! [[ "${MIN_RUNNERS}" =~ ^[0-9]+$ ]]; then
               MIN_RUNNERS=0
@@ -274,7 +282,106 @@ jobs:
             echo "Pod Details:"
             kubectl get pods -n "${NAMESPACE}" -l runner-deployment-name="${RELEASE_NAME}" 2>/dev/null || echo "Could not retrieve pod details"
           fi
-      
+
+      - name: Check memory headroom and OOM kills
+        if: steps.deployment.outputs.deployed == 'true'
+        id: memory
+        continue-on-error: true
+        run: |
+          echo "🧠 Checking runner memory headroom and OOM history..."
+          NAMESPACE="${{ needs.validate-inputs.outputs.namespace }}"
+
+          # --- Node headroom -------------------------------------------------
+          # Requires metrics-server (.github/workflows/deploy-cluster-addons.yml).
+          echo ""
+          echo "Runner node usage:"
+          if kubectl top nodes --no-headers >/dev/null 2>&1; then
+            kubectl top nodes --no-headers 2>/dev/null | grep '^github-runners-pool' \
+              || echo "  (no runner nodes reporting)"
+          else
+            echo "  ⚠️ metrics API unavailable - is metrics-server deployed?"
+            echo "     Run the 'Deploy Cluster Addons' workflow."
+          fi
+
+          echo ""
+          echo "Runner container usage (runner = job process, dind = Docker builds):"
+          kubectl top pods -n "${NAMESPACE}" --containers --no-headers 2>/dev/null \
+            || echo "  (no metrics available)"
+
+          # --- OOM kills -----------------------------------------------------
+          # Runner pods are ephemeral and are deleted when a job finishes, so a
+          # pod that was OOMKilled mid-job is usually already gone. Check both
+          # live pod state and the (roughly 1 hour) event window.
+          echo ""
+          PODS_JSON=$(kubectl get pods -n "${NAMESPACE}" -o json 2>/dev/null || echo '{"items":[]}')
+
+          OOM_DETAIL=$(echo "${PODS_JSON}" | jq -r '
+            .items[]
+            | .metadata.name as $pod
+            | (.status.containerStatuses // []) + (.status.initContainerStatuses // [])
+            | .[]
+            | select((.state.terminated.reason // .lastState.terminated.reason) == "OOMKilled")
+            | "  " + $pod + " / " + .name
+          ')
+          OOM_COUNT=$(echo "${OOM_DETAIL}" | grep -c '/' || true)
+
+          EVICTED=$(echo "${PODS_JSON}" | jq -r '
+            [.items[] | select(.status.reason == "Evicted")] | length
+          ')
+
+          OOM_EVENTS=$(kubectl get events -n "${NAMESPACE}" --sort-by=.lastTimestamp 2>/dev/null \
+            | grep -Ei 'oomkill|evict' | tail -10 || true)
+
+          echo "OOM kills in live pods: ${OOM_COUNT}"
+          if [ "${OOM_COUNT}" -gt 0 ]; then
+            echo "${OOM_DETAIL}"
+            echo ""
+            echo "  → container 'runner' = the job process itself (raise the runner limit)"
+            echo "  → container 'dind'   = a Docker build (raise the dind limit)"
+            echo "  See docs/runbooks/node-pool-sizing.md"
+          fi
+          echo "Evicted pods: ${EVICTED}"
+          if [ -n "${OOM_EVENTS}" ]; then
+            echo ""
+            echo "Recent OOM/eviction events:"
+            echo "${OOM_EVENTS}"
+          fi
+
+          echo "oom_count=${OOM_COUNT}" >> $GITHUB_OUTPUT
+          echo "evicted_count=${EVICTED}" >> $GITHUB_OUTPUT
+
+          # --- Capacity drift ------------------------------------------------
+          # One runner pod per node, so max_nodes must be >= maxRunners or the
+          # extra runners can never be scheduled. This catches the case where
+          # maxRunners was raised without resizing the pool.
+          echo ""
+          MAX_RUNNERS="${{ steps.config.outputs.max_runners }}"
+          CLUSTER_ID=$(doctl kubernetes cluster list -o json 2>/dev/null \
+            | jq -r --arg n "${CLUSTER_NAME}" '.[] | select(.name==$n) | .id')
+
+          if [ -n "${CLUSTER_ID}" ] && [ "${CLUSTER_ID}" != "null" ]; then
+            POOL_JSON=$(doctl kubernetes cluster node-pool list "${CLUSTER_ID}" -o json 2>/dev/null \
+              | jq -r '.[] | select(.name=="github-runners-pool-16g")')
+            POOL_MIN=$(echo "${POOL_JSON}" | jq -r '.min_nodes // "?"')
+            POOL_MAX=$(echo "${POOL_JSON}" | jq -r '.max_nodes // "?"')
+            POOL_COUNT=$(echo "${POOL_JSON}" | jq -r '.count // "?"')
+
+            echo "Node pool: min_nodes=${POOL_MIN} max_nodes=${POOL_MAX} current=${POOL_COUNT}"
+            echo "Scale set: maxRunners=${MAX_RUNNERS}"
+
+            if [[ "${POOL_MAX}" =~ ^[0-9]+$ ]] && [[ "${MAX_RUNNERS}" =~ ^[0-9]+$ ]] \
+               && [ "${POOL_MAX}" -lt "${MAX_RUNNERS}" ]; then
+              echo "⚠️ CAPACITY DRIFT: max_nodes (${POOL_MAX}) < maxRunners (${MAX_RUNNERS})."
+              echo "   One runner pod is scheduled per node, so runners above"
+              echo "   ${POOL_MAX} will sit Pending forever."
+              echo "   Fix with the 'Node Pool Sizing' workflow."
+            else
+              echo "✅ Node pool capacity is consistent with maxRunners"
+            fi
+          else
+            echo "⚠️ Could not resolve cluster '${CLUSTER_NAME}' to check pool capacity"
+          fi
+
       - name: Check GitHub registration
         if: steps.deployment.outputs.deployed == 'true'
         id: github

--- a/.github/workflows/scale-runners.yml
+++ b/.github/workflows/scale-runners.yml
@@ -259,11 +259,11 @@ jobs:
               --namespace "${NAMESPACE}" \
               --reuse-values \
               --set minRunners=2 \
-              --set maxRunners=4 \
+              --set maxRunners=8 \
               --wait \
               --timeout 180s; then
               
-              echo "✅ Scaled to: Min=2, Max=4"
+              echo "✅ Scaled to: Min=2, Max=8"
               break
             elif [ "${attempt}" = "3" ]; then
               echo "❌ Error: Failed to scale up runners"
@@ -275,7 +275,7 @@ jobs:
           done
           
           echo "## ✅ Scaled Up" >> $GITHUB_STEP_SUMMARY
-          echo "Runners scaled to: **Min=2, Max=4**" >> $GITHUB_STEP_SUMMARY
+          echo "Runners scaled to: **Min=2, Max=8**" >> $GITHUB_STEP_SUMMARY
       
       - name: Scale down (minimal)
         if: needs.validate-inputs.outputs.action == 'scale-down'
@@ -401,7 +401,7 @@ jobs:
             # Verify scaling worked as expected
             case "${{ needs.validate-inputs.outputs.action }}" in
               scale-up)
-                if [ "${NEW_MIN}" = "2" ] && [ "${NEW_MAX}" = "4" ]; then
+                if [ "${NEW_MIN}" = "2" ] && [ "${NEW_MAX}" = "8" ]; then
                   echo "✅ Scale up verified"
                 else
                   echo "⚠️ Scale up may not have applied correctly"

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -1,0 +1,149 @@
+name: Validate Config
+
+# PR-time validation for everything that is not the Docker image.
+#
+# Before this workflow, the only pull_request-triggered job was
+# build-runner-image.yml, and it is path-filtered to Dockerfile-related files.
+# That meant deploy/dind-values.yaml - the file that controls production runner
+# CPU and memory - could be changed and merged with no automated check at all.
+#
+# Runs on ubuntu-latest rather than the self-hosted runners on purpose: this
+# workflow validates the runner configuration itself, so it must still work when
+# the runners are misconfigured, saturated, or scaled to zero. The repository is
+# public, so GitHub-hosted minutes are free.
+
+on:
+  pull_request:
+    paths:
+      - 'deploy/**'
+      - 'scripts/**'
+      - 'test/**'
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/**'
+      - 'scripts/**'
+      - 'test/**'
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate workflows, scripts and runner config
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate YAML syntax
+        run: |
+          echo "🔍 Parsing all workflow and deployment YAML..."
+          python3 - <<'PY'
+          import glob, sys, yaml
+
+          failures = []
+          files = sorted(glob.glob('.github/workflows/*.yml')) \
+                + sorted(glob.glob('.github/actions/*/action.yml')) \
+                + sorted(glob.glob('deploy/*.yaml'))
+
+          for f in files:
+              try:
+                  yaml.safe_load(open(f, encoding='utf-8'))
+                  print(f'  OK   {f}')
+              except Exception as e:
+                  failures.append((f, e))
+                  print(f'  FAIL {f}: {e}')
+
+          if failures:
+              print(f'\n{len(failures)} file(s) failed to parse')
+              sys.exit(1)
+          print(f'\nAll {len(files)} file(s) parsed successfully')
+          PY
+
+      - name: Lint GitHub Actions workflows
+        run: |
+          echo "🔍 Running actionlint..."
+          # Pinned release rather than `| bash` of a floating installer.
+          ACTIONLINT_VERSION=1.7.7
+          curl -sSLo actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          tar -xzf actionlint.tar.gz actionlint
+          # -shellcheck= / -pyflakes= disable actionlint's embedded passes over
+          # `run:` blocks. Shell scripts are linted directly in the dedicated
+          # shellcheck step below at severity=error; the embedded pass reports
+          # every severity and would flood this check with style findings from
+          # workflows that predate it. This lints workflow STRUCTURE only:
+          # syntax, expressions, contexts, action refs, matrix and `needs` wiring.
+          ./actionlint -color -shellcheck= -pyflakes= .github/workflows/*.yml
+
+      - name: Check shell script syntax
+        run: |
+          echo "🔍 Running bash -n on all scripts..."
+          FAILED=0
+          for s in scripts/*.sh test/*.sh deploy/*.sh docs/codex/*.sh; do
+            [ -e "$s" ] || continue
+            if bash -n "$s" 2>/dev/null; then
+              echo "  OK   $s"
+            else
+              echo "  FAIL $s"
+              bash -n "$s" || true
+              FAILED=1
+            fi
+          done
+          [ "$FAILED" = "0" ] || exit 1
+
+      - name: Shellcheck (errors only)
+        run: |
+          echo "🔍 Running shellcheck at severity=error..."
+          # Errors only: these scripts predate this check and style-level
+          # findings would be noise. Genuine errors still fail the build.
+          shellcheck -S error scripts/*.sh test/*.sh deploy/*.sh || exit 1
+          echo "✅ No shellcheck errors"
+
+      - name: Verify runner resource reservations
+        run: |
+          echo "🔍 Verifying runner memory reservations and pod-per-node invariant..."
+          # Guards against silently reintroducing containerMode.type: dind,
+          # which would drop the Docker daemon's memory reservation with no
+          # error and no visible diff in the values file.
+          chmod +x test/verify-runner-resources.sh
+          ./test/verify-runner-resources.sh
+
+      - name: Check for secrets in tracked files
+        run: |
+          echo "🔍 Checking that no token-like values were committed..."
+          # deploy/dind-values.yaml must keep github_token empty - it is set at
+          # deploy time via --set.
+          TOKEN_LINE=$(grep -E '^\s*github_token:' deploy/dind-values.yaml || true)
+          if echo "${TOKEN_LINE}" | grep -qE 'github_token:\s*"?(gh[pousr]_|[A-Za-z0-9]{20,})'; then
+            echo "❌ deploy/dind-values.yaml appears to contain a real token!"
+            exit 1
+          fi
+          echo "✅ github_token is not populated in committed values"
+
+          if git ls-files --error-unmatch .env >/dev/null 2>&1; then
+            echo "❌ .env is tracked by git"
+            exit 1
+          fi
+          echo "✅ .env is not tracked"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Config Validation"
+            echo ""
+            echo "- YAML syntax (workflows, composite actions, deploy values)"
+            echo "- actionlint"
+            echo "- \`bash -n\` + shellcheck (errors) on all scripts"
+            echo "- Runner memory reservations and the one-pod-per-node invariant"
+            echo "- No committed tokens"
+          } >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,10 @@ otherwise.
 # Deployment verification
 ./test/test-deployment.sh
 
+# Runner memory reservations and the one-pod-per-node invariant.
+# Renders deploy/dind-values.yaml with Helm; needs no cluster access.
+./test/verify-runner-resources.sh
+
 # Security and runtime verification
 ./test/verify-docker-version.sh
 ./test/verify-go-runtime.sh

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Deploy secure, scalable GitHub Actions self-hosted runners on Kubernetes with co
 - **GitHub-first deployment**: Deploy, scale, monitor, and emergency-stop runners from GitHub Actions.
 - **Complete Development Environment**: Python 3.13, Node.js 22, uv, AWS CLI v2, Terraform, kubectl, Helm, and more
 - **Security Tools**: kubeconform 0.7.0, kubesec 2.14.2, Trivy 0.70.0
-- **Docker-in-Docker Support**: Build containers within runners
-- **Auto-scaling**: Configurable min/max runner instances (2-4 default, 4-8 maximum)
+- **Docker-in-Docker Support**: Build containers within runners, with a dedicated memory reservation for the Docker daemon
+- **Auto-scaling**: Configurable min/max runner instances (2 warm / 8 maximum by default)
 - **Production Ready**: Resource limits, health checks, and monitoring
 - **Dual Configuration**: Template versions for reuse and production configs for Red Duck Labs
 - **Security optimized**: Multi-stage build with SHA256/GPG-verified tools and a machine-enforced CVE-floor gate
@@ -28,8 +28,14 @@ Configure these secrets in your repository settings (`Settings → Secrets and v
    - [Create in DigitalOcean Control Panel](https://cloud.digitalocean.com/account/api/tokens)
 
 ### Infrastructure Requirements
-- Kubernetes cluster (1.24+) - Red Duck Labs uses DigitalOcean
+- **Kubernetes cluster 1.29+** - Red Duck Labs uses DigitalOcean (currently 1.33).
+  1.29 is a hard floor: the Docker-in-Docker daemon runs as a *native sidecar*
+  (an init container with `restartPolicy: Always`), which earlier versions ignore.
 - DigitalOcean Container Registry (for custom images)
+- A dedicated, labeled and tainted node pool for runners
+  (`node-type=github-runner`, taint `github-runner=true:NoSchedule`), sized so
+  that one runner pod fits per node - see
+  [docs/runbooks/node-pool-sizing.md](docs/runbooks/node-pool-sizing.md)
 
 ## Quick Start - GitHub Actions Deployment
 
@@ -45,7 +51,7 @@ Configure these secrets in your repository settings (`Settings → Secrets and v
 3. Click **"Run workflow"**
 4. Configure options (or use defaults):
    - Min runners: 2
-   - Max runners: 4
+   - Max runners: 8
    - Runner image: `registry.digitalocean.com/redducklabs/github-runner:latest`
 5. Click **"Run workflow"** to deploy
 
@@ -193,6 +199,37 @@ guide and update the pinned fingerprint in the Dockerfile and in
 `test/verify-aws-key-expiry.sh`. Locally, `--no-cache` (or bumping
 `AWSCLI_VERSION`) forces the in-image check to re-run.
 
+## Runner Capacity and Memory
+
+| | Value |
+|---|---|
+| Concurrent runners | **8** (`maxRunners`), 2 always warm (`minRunners`) |
+| Memory per job | **~12.5Gi usable** - runner limit 10Gi, Docker daemon limit 10Gi |
+| CPU per job | All 8 vCPU (no CPU limit) |
+| Node pool | `github-runners-pool-16g`, `s-8vcpu-16gb`, autoscaling 2-8 nodes |
+| Cost | **$192/mo floor** (2 warm nodes), **$768/mo ceiling** (8 nodes, only while 8 jobs run) |
+
+**One runner pod runs per node.** The pod requests 10Gi of memory (runner 5Gi +
+dind 5Gi) against ~13.32Gi of node allocatable, so two pods cannot share a node
+and the cluster-autoscaler adds a node per concurrent job. This is deliberate:
+it stops one job's `docker build` from starving another's, which was the cause
+of intermittent out-of-memory failures.
+
+Two consequences worth knowing:
+
+- **`maxRunners` and the pool's `max_nodes` must be raised together.** Runners
+  above `max_nodes` sit `Pending` forever. The **Node Pool Sizing** workflow
+  enforces this, and **Deploy GitHub Runners** and **Runner Status** both warn
+  on drift.
+- **Jobs beyond the warm pool wait for a node** to be provisioned and the
+  ~1.34GB runner image to be pulled. `minRunners`/`min_nodes` is the dial that
+  trades money for that latency.
+
+Memory is split into two independent budgets - the `runner` container for work
+run directly on the runner, and the `dind` sidecar for anything run inside
+Docker. See [docs/runbooks/node-pool-sizing.md](docs/runbooks/node-pool-sizing.md)
+for how to change any of this.
+
 ## GitHub Actions Management
 
 Use GitHub Actions for normal runner fleet operations. Local scripts are
@@ -204,7 +241,9 @@ available for investigation and explicitly requested operations.
 |----------|-------------|---------|
 | **Deploy GitHub Runners** | Initial deployment or updates | Manual (`workflow_dispatch`) |
 | **Scale GitHub Runners** | Scale up/down/custom | Manual (`workflow_dispatch`) |
-| **Runner Status** | Check runner health and registration | Manual + Daily at 9 AM UTC |
+| **Node Pool Sizing** | Set node pool min/max nodes (runner capacity ceiling) | Manual (`workflow_dispatch`) |
+| **Deploy Cluster Addons** | Deploy metrics-server (`kubectl top`) | Manual (`workflow_dispatch`) |
+| **Runner Status** | Runner health, registration, memory headroom, OOM kills | Manual + Daily at 9 AM UTC |
 | **Emergency Stop Runners** | Emergency shutdown with recovery info | Manual (requires confirmation) |
 | **Build Custom Runner Image** | Build and push Docker image | Push to Dockerfile or manual |
 
@@ -270,6 +309,7 @@ the live runner fleet, so use them only when local operations are intended.
 ```bash
 ./test/verify-tools.sh
 ./test/test-deployment.sh
+./test/verify-runner-resources.sh   # memory reservations + one-pod-per-node (no cluster needed)
 ./test/verify-cve-floor.sh <image>
 ./test/verify-aws-key-expiry.sh docker/aws-cli-public.key
 ./test/verify-docker-version.sh
@@ -341,12 +381,41 @@ curl -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/orgs/redducklabs/actions/runners
 ```
 
+### Diagnosing Out-Of-Memory Failures
+
+The runner container and the Docker daemon have **separate memory budgets**, so
+an OOM kill names the one that overran:
+
+```bash
+# Live memory use per container
+kubectl top pods -n arc-runners --containers
+
+# Node headroom
+kubectl top nodes
+
+# Recent OOM kills and evictions (runner pods are ephemeral - check promptly)
+kubectl get events -n arc-runners --sort-by=.lastTimestamp | grep -Ei 'oom|evict'
+```
+
+| Container killed | Cause | Fix |
+|---|---|---|
+| `runner` | The job process itself (npm, jest, webpack, pytest, go build) | Raise the `runner` memory limit, or lower the job's own worker count |
+| `dind` | A Docker build, compose, or testcontainers | Raise the `dind` memory limit |
+
+Both limits are in `deploy/dind-values.yaml`. The scheduled **Runner Status**
+workflow reports the same information on every run.
+
 ### Common Issues
 
 - **Pods stuck in Init**: Check image pull secrets and registry access
 - **Runners not appearing**: Verify GitHub token has correct scopes
 - **Build failures**: Ensure Docker-in-Docker is properly configured
 - **Scaling issues**: Check AutoScalingRunnerSet status
+- **Runners stuck `Pending`**: `maxRunners` likely exceeds the node pool's
+  `max_nodes`. One runner pod runs per node - see
+  [docs/runbooks/node-pool-sizing.md](docs/runbooks/node-pool-sizing.md)
+- **`kubectl top` says "Metrics API not available"**: run the
+  **Deploy Cluster Addons** workflow to install metrics-server
 
 ## Security & Optimization
 

--- a/deploy/dind-values.template.yaml
+++ b/deploy/dind-values.template.yaml
@@ -10,25 +10,97 @@ githubConfigUrl: "https://github.com/YOUR_ORG_OR_REPO"
 githubConfigSecret:
   github_token: ""  # SET VIA ENVIRONMENT VARIABLE
 
-# Runner scaling configuration
+# Runner scaling configuration.
+# Size these against your node pool: the resource requests below decide how many
+# runner pods fit on a node, and therefore how many nodes maxRunners needs.
 minRunners: 2
 maxRunners: 4
 
 # Runner scale set name (used in workflows as: runs-on: your-runner-name)
 runnerScaleSetName: "YOUR-RUNNER-NAME"
 
-# Enable Docker-in-Docker mode
-containerMode:
-  type: "dind"
-  
-# Runner template configuration for DinD
+# NOTE: containerMode.type is deliberately NOT set to "dind".
+#
+# ARC's built-in dind mode renders the Docker daemon sidecar from a hardcoded
+# chart template with no `resources` field, and a user-supplied container named
+# "dind" is filtered out of values. The result is a dockerd with no memory
+# request and no memory limit, so every `docker build` competes for whatever
+# node memory happens to be unreserved - which causes intermittent, hard to
+# attribute out-of-memory failures.
+#
+# Declaring the sidecar ourselves (the chart's "default" container mode) is the
+# only way to give dockerd a memory reservation. The spec below reproduces what
+# containerMode: "dind" generates, plus resources and a pinned image.
+#
+# To confirm it still matches your chart version, diff these two renders:
+#   helm template test <chart> --version <ver> --kube-version <kver> -f dind-values.yaml
+#
+# Things you now own that the chart used to own - keep them in sync on upgrade:
+#   - init-dind-externals init container
+#   - dind sidecar (restartPolicy: Always -> requires Kubernetes >= 1.29)
+#   - DOCKER_GROUP_GID and the matching dockerd --group flag
+#   - work / dind-sock / dind-externals volumes
+#   - DOCKER_HOST and RUNNER_WAIT_FOR_DOCKER_IN_SECONDS on the runner
+
+# Runner template configuration
 template:
   spec:
     # Pull secret for private registry (if using custom image)
     # Uncomment and configure if using private registry
     # imagePullSecrets:
     # - name: your-registry-secret
-    
+
+    initContainers:
+    # Copies the runner's externals into a shared volume so dockerd can reach them.
+    - name: init-dind-externals
+      # REPLACE: must be the SAME image as the runner container below
+      image: YOUR_REGISTRY/YOUR_IMAGE:TAG
+      command: ["cp"]
+      args: ["-r", "/home/runner/externals/.", "/home/runner/tmpDir/"]
+      volumeMounts:
+      - name: dind-externals
+        mountPath: /home/runner/tmpDir
+
+    # Docker daemon, run as a native sidecar (restartPolicy: Always on an init
+    # container). Requires Kubernetes >= 1.29.
+    - name: dind
+      # Pin this. The chart uses the floating `docker:dind` tag, which silently
+      # changes the Docker version underneath your builds.
+      image: docker:29.7.2-dind
+      args:
+        - dockerd
+        - --host=unix:///var/run/docker.sock
+        - --group=$(DOCKER_GROUP_GID)
+      env:
+        - name: DOCKER_GROUP_GID
+          value: "123"
+      securityContext:
+        privileged: true
+      restartPolicy: Always
+      startupProbe:
+        exec:
+          command:
+            - docker
+            - info
+        initialDelaySeconds: 0
+        failureThreshold: 24
+        periodSeconds: 5
+      # Memory for everything run INSIDE Docker (docker build, compose,
+      # testcontainers). Without this the daemon is unreserved and unbounded.
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "2Gi"
+        limits:
+          memory: "4Gi"
+      volumeMounts:
+      - name: work
+        mountPath: /home/runner/_work
+      - name: dind-sock
+        mountPath: /var/run
+      - name: dind-externals
+        mountPath: /home/runner/externals
+
     # Container configuration
     containers:
     - name: runner
@@ -37,17 +109,42 @@ template:
       # For default: ghcr.io/actions/actions-runner:latest
       image: YOUR_REGISTRY/YOUR_IMAGE:TAG
       imagePullPolicy: Always
-      
+
       # CRITICAL: Must specify the command for ARC to work properly
       command: ["/home/runner/run.sh"]
-      
-      # Resource limits - adjust as needed
+
+      # In the chart's dind mode these were injected automatically; in default
+      # mode you own them.
+      env:
+      - name: DOCKER_HOST
+        value: unix:///var/run/docker.sock
+      - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
+        value: "120"
+
+      # Memory for work run DIRECTLY on the runner (npm, jest, pytest, go build)
+      # - as opposed to work run inside Docker, which is charged to dind above.
+      #
+      # Sizing rule: (runner requests + dind requests) x pods-per-node must fit
+      # inside node allocatable, minus what system DaemonSets take. Requests
+      # decide packing density; limits decide what a job can actually use.
       resources:
         limits:
-          cpu: "2"
           memory: "4Gi"
         requests:
           cpu: "500m"
           memory: "1Gi"
-    
-    # Docker-in-Docker sidecar container (automatically added by ARC when containerMode.type: "dind")
+
+      volumeMounts:
+      - name: work
+        mountPath: /home/runner/_work
+      - name: dind-sock
+        mountPath: /var/run
+
+    # Owned by you in default container mode (the chart creates these in dind mode).
+    volumes:
+    - name: work
+      emptyDir: {}
+    - name: dind-sock
+      emptyDir: {}
+    - name: dind-externals
+      emptyDir: {}

--- a/deploy/dind-values.yaml
+++ b/deploy/dind-values.yaml
@@ -10,33 +10,52 @@ githubConfigUrl: "https://github.com/redducklabs"
 githubConfigSecret:
   github_token: ""  # SET VIA ENVIRONMENT VARIABLE
 
-# Runner scaling configuration
+# Runner scaling configuration.
+# One runner pod per node (see the resource note below), so maxRunners must not
+# exceed the node pool's max_nodes and minRunners must not exceed min_nodes.
+# Pool bounds are applied by .github/workflows/node-pool-sizing.yml; see
+# docs/runbooks/node-pool-sizing.md before changing either number.
 minRunners: 2
-maxRunners: 6
+maxRunners: 8
 
 # Runner scale set name (used in workflows as: runs-on: redducklabs-runners)
 runnerScaleSetName: "redducklabs-runners"
 
-# Enable Docker-in-Docker mode
-containerMode:
-  type: "dind"
-  
-# Runner template configuration for DinD
+# NOTE: containerMode.type is deliberately NOT set to "dind".
+#
+# ARC's built-in dind mode (containerMode.type: "dind") renders the Docker
+# daemon sidecar from a hardcoded chart template that has no `resources` field,
+# and a user-supplied container named "dind" is explicitly filtered out of
+# values (see gha-runner-scale-set.non-runner-non-dind-containers). That is true
+# in chart 0.12.1 and in 0.14.2. The result is a dockerd with NO memory request
+# and NO memory limit: every `docker build` competed for whatever node memory
+# happened to be unreserved, which is what caused the intermittent OOMs.
+#
+# Declaring the dind sidecar ourselves (the chart's "default" container mode) is
+# the only way to give dockerd a memory reservation. The spec below is a
+# byte-for-byte reproduction of what containerMode: "dind" generated, plus
+# resources and a pinned image. Regenerate the comparison with:
+#
+#   helm template redducklabs-runners \
+#     oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
+#     --version 0.12.1 --kube-version 1.33.12 -f deploy/dind-values.yaml
+#
+# Anything we now own that the chart used to own:
+#   - init-dind-externals init container
+#   - dind sidecar (restartPolicy: Always -> requires Kubernetes >= 1.29)
+#   - DOCKER_GROUP_GID=123 and dockerd --group=123 (must stay in sync)
+#   - work / dind-sock / dind-externals volumes
+#   - DOCKER_HOST and RUNNER_WAIT_FOR_DOCKER_IN_SECONDS on the runner
+# When bumping the chart version, re-render and re-diff this spec.
+
+# Runner template configuration
 template:
   spec:
-    # Pin runners to the dedicated github-runners-pool so they do not
+    # Pin runners to the dedicated github-runners-pool-16g so they do not
     # co-locate with production workloads (postgres, backend) on worker-pool.
     # That pool is labeled node-type=github-runner and tainted
     # github-runner=true:NoSchedule, so BOTH a nodeSelector and a matching
     # toleration are required for runners to land there.
-    #
-    # Pool sizing (see ops notes): github-runners-pool is s-8vcpu-16gb,
-    # autoscaling 1->4 nodes. The 5Gi runner memory request below intentionally
-    # reserves a pod's share of a node (~half of ~14Gi allocatable) so the
-    # scheduler packs exactly 2 runners per node and the cluster-autoscaler adds
-    # a node per additional pair instead of bin-packing builds until they OOM.
-    # The reservation also covers the DinD sidecar, which ARC injects with no
-    # resource requests of its own.
     nodeSelector:
       node-type: github-runner
     tolerations:
@@ -48,27 +67,110 @@ template:
     # Pull secret for private registry
     imagePullSecrets:
     - name: do-registry-secret
-    
+
+    initContainers:
+    # Copies the runner's externals into a shared volume so dockerd can reach
+    # them. Reproduced from the chart's dind-init-container helper.
+    - name: init-dind-externals
+      image: registry.digitalocean.com/redducklabs/github-runner:latest
+      command: ["cp"]
+      args: ["-r", "/home/runner/externals/.", "/home/runner/tmpDir/"]
+      volumeMounts:
+      - name: dind-externals
+        mountPath: /home/runner/tmpDir
+
+    # Docker daemon, run as a native sidecar (restartPolicy: Always on an init
+    # container). Requires Kubernetes >= 1.29; the cluster is 1.33.
+    #
+    # Image is pinned. The chart used the floating `docker:dind` tag, which
+    # resolved to 29.7.2 at the time of this change - this pin is that same
+    # version, so it is a reproducibility fix and not a behavioural change.
+    - name: dind
+      image: docker:29.7.2-dind
+      args:
+        - dockerd
+        - --host=unix:///var/run/docker.sock
+        - --group=$(DOCKER_GROUP_GID)
+      env:
+        - name: DOCKER_GROUP_GID
+          value: "123"
+      securityContext:
+        privileged: true
+      restartPolicy: Always
+      startupProbe:
+        exec:
+          command:
+            - docker
+            - info
+        initialDelaySeconds: 0
+        failureThreshold: 24
+        periodSeconds: 5
+      # Memory reservation for the Docker daemon. THIS IS THE FIX: everything a
+      # workflow runs inside Docker (docker build, compose, testcontainers) is
+      # charged here, not to the runner container. Previously this was 0/0.
+      resources:
+        requests:
+          cpu: "1"
+          memory: "5Gi"
+        limits:
+          memory: "10Gi"
+      volumeMounts:
+      - name: work
+        mountPath: /home/runner/_work
+      - name: dind-sock
+        mountPath: /var/run
+      - name: dind-externals
+        mountPath: /home/runner/externals
+
     # Container configuration
     containers:
     - name: runner
       # Custom image with all tools installed
       image: registry.digitalocean.com/redducklabs/github-runner:latest
       imagePullPolicy: Always
-      
+
       # CRITICAL: Must specify the command for ARC to work properly
       command: ["/home/runner/run.sh"]
-      
+
+      # In the chart's dind mode these two were injected automatically. In
+      # default mode we own them: DOCKER_HOST points the runner at the sidecar's
+      # socket, and RUNNER_WAIT_FOR_DOCKER_IN_SECONDS keeps the runner from
+      # starting a job before dockerd is listening.
+      env:
+      - name: DOCKER_HOST
+        value: unix:///var/run/docker.sock
+      - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
+        value: "120"
+
       # Resource limits.
-      # memory request 5Gi -> forces 2 runners per s-8vcpu-16gb node (see note
-      # above). cpu kept modest so memory is the binding constraint for packing.
+      #
+      # Sizing rationale (github-runners-pool-16g, s-8vcpu-16gb):
+      #   node allocatable       13.32Gi / 7880m cpu
+      #   less system pods       ~0.68Gi (cilium, kube-proxy, csi, node-agent)
+      #   available to the pod   ~12.64Gi
+      #
+      # runner 5Gi + dind 5Gi = 10Gi of memory REQUESTS per pod. Two pods would
+      # need 20Gi against 13.32Gi allocatable, so the scheduler places exactly
+      # ONE runner pod per node and the cluster-autoscaler adds a node per
+      # additional concurrent job. Requests are deliberately below the ~12.64Gi
+      # budget so system DaemonSets keep room; the LIMITS are what a job can
+      # actually consume.
+      #
+      # No CPU limit: with one pod per node there is nothing to protect the node
+      # from, and the previous 3-CPU limit throttled builds to 3 of 8 cores.
+      #
+      # Memory limits are intentionally overcommitted (10Gi + 10Gi against a
+      # ~12.64Gi node) so a runner-heavy job can use ~10Gi on the runner while
+      # dockerd idles, and a Docker-heavy job can do the reverse. With one pod
+      # per node the only workload at risk from that overcommit is the job
+      # itself. An OOM now names the container that overran, which is how we
+      # attribute failures: `runner` = the job process, `dind` = a Docker build.
       resources:
-        limits:
-          cpu: "3"
-          memory: "6Gi"
         requests:
-          cpu: "1"
+          cpu: "2"
           memory: "5Gi"
+        limits:
+          memory: "10Gi"
 
       # Runner container securityContext.
       # allowPrivilegeEscalation MUST be true and the default capability set
@@ -76,7 +178,7 @@ template:
       # `sudo` (e.g. `sudo apt-get install libmagic1`, `sudo mv kubeval ...`).
       # Setting allowPrivilegeEscalation: false (NoNewPrivs) or dropping all
       # capabilities breaks sudo/apt/dpkg. The isolation boundary for these
-      # runners is the pod itself (the DinD sidecar already runs privileged),
+      # runners is the pod itself (the dind sidecar already runs privileged),
       # not in-container privilege restriction. Accepted risk is documented in
       # docs/security/vulnerability-dismissals.md.
       securityContext:
@@ -84,5 +186,21 @@ template:
         runAsGroup: 121
         allowPrivilegeEscalation: true
         readOnlyRootFilesystem: false
-    
-    # Docker-in-Docker sidecar container (automatically added by ARC when containerMode.type: "dind")
+
+      volumeMounts:
+      - name: work
+        mountPath: /home/runner/_work
+      - name: dind-sock
+        mountPath: /var/run
+
+    # Owned by us in default container mode (the chart created these in dind
+    # mode). `work` is the runner's job workspace; dind-sock carries the Docker
+    # socket between the sidecar and the runner; dind-externals carries the
+    # runner externals copied by the init container.
+    volumes:
+    - name: work
+      emptyDir: {}
+    - name: dind-sock
+      emptyDir: {}
+    - name: dind-externals
+      emptyDir: {}

--- a/deploy/metrics-server-values.yaml
+++ b/deploy/metrics-server-values.yaml
@@ -1,0 +1,40 @@
+# metrics-server configuration for redducklabs-cluster
+#
+# metrics-server backs `kubectl top nodes` and `kubectl top pods`. Without it
+# there is no way to see how much memory a runner or its Docker daemon is
+# actually using, which is what made the runner out-of-memory failures hard to
+# attribute. DOKS does not ship it by default on this cluster.
+#
+# Deployed by .github/workflows/deploy-cluster-addons.yml.
+
+# NOTE: --kubelet-insecure-tls is deliberately NOT set.
+#
+# Many metrics-server guides tell you to add it. On this DOKS cluster it is not
+# needed: the kubelet serving certificates validate against the cluster CA, and
+# metrics-server was verified serving `kubectl top nodes` with TLS verification
+# fully enabled. Do not add it to "fix" a scrape failure without first checking
+# what the real error is - it disables verification of every kubelet connection.
+#
+# `args` is intentionally left unset. The chart's `defaultArgs` already supplies
+# --cert-dir, --kubelet-preferred-address-types, --kubelet-use-node-status-port
+# and --metric-resolution, and the chart APPENDS `args` to `defaultArgs` rather
+# than replacing them - so repeating a default flag here passes it twice.
+
+# Small, bounded footprint. metrics-server holds only a short in-memory window
+# of samples, so this scales with node/pod count rather than with load.
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    memory: 256Mi
+
+# No toleration for the github-runner taint on purpose: the runner pool is sized
+# for exactly one runner pod per node, and an addon scheduled there would eat
+# into that budget. metrics-server runs on worker-pool and scrapes the runner
+# kubelets over the network.
+
+replicas: 1
+
+podDisruptionBudget:
+  enabled: false

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -26,7 +26,7 @@ The easiest way to deploy runners is directly from GitHub Actions - no local set
 3. Click **"Run workflow"** button
 4. Configure deployment options:
    - **Min runners**: Minimum number of runners (default: 2)
-   - **Max runners**: Maximum number of runners (default: 4)
+   - **Max runners**: Maximum number of runners (default: 8)
    - **Runner image**: Docker image to use (default: `registry.digitalocean.com/redducklabs/github-runner:latest`)
    - **Namespace**: Kubernetes namespace (default: `arc-runners`)
 5. Click **"Run workflow"** to start deployment
@@ -136,7 +136,7 @@ REGISTRY_NAMESPACE=redducklabs
 RELEASE_NAME=redducklabs-runners
 RUNNER_SCALE_SET_NAME=redducklabs-runners
 MIN_RUNNERS=2
-MAX_RUNNERS=4
+MAX_RUNNERS=8
 ```
 
 ### 3. Container Registry Setup
@@ -223,6 +223,9 @@ curl -H "Authorization: token $GITHUB_TOKEN" \
 
 The `deploy/dind-values.yaml` file contains the main configuration:
 
+Abridged - see `deploy/dind-values.yaml` for the full file and the reasoning
+comments.
+
 ```yaml
 # GitHub configuration
 githubConfigUrl: "https://github.com/redducklabs"
@@ -230,30 +233,83 @@ runnerScaleSetName: "redducklabs-runners"
 
 # Scaling settings
 minRunners: 2
-maxRunners: 4
+maxRunners: 8
 
-# Container configuration
+# NOTE: containerMode.type is deliberately NOT "dind" - see below.
 template:
   spec:
+    initContainers:
+    - name: init-dind-externals
+      # ... copies runner externals into a shared volume
+    - name: dind                      # Docker daemon, as a native sidecar
+      image: docker:29.7.2-dind
+      restartPolicy: Always
+      securityContext:
+        privileged: true
+      resources:                      # memory for everything run IN Docker
+        requests:
+          cpu: "1"
+          memory: "5Gi"
+        limits:
+          memory: "10Gi"
+
     containers:
     - name: runner
       image: registry.digitalocean.com/redducklabs/github-runner:latest
-      resources:
-        limits:
-          cpu: "2"
-          memory: "4Gi"
+      resources:                      # memory for work run ON the runner
         requests:
-          cpu: "500m"
-          memory: "1Gi"
+          cpu: "2"
+          memory: "5Gi"
+        limits:
+          memory: "10Gi"              # no CPU limit: one pod per node
 ```
 
 ### Key Configuration Options
 
-- **minRunners**: Always-on runners (recommendation: 2)
-- **maxRunners**: Maximum concurrent runners (recommendation: 4-8)
-- **CPU/Memory**: Resource limits per runner
-- **Image**: Custom runner image with pre-installed tools
-- **Pull Secrets**: For accessing private registries
+- **minRunners**: Always-on runners. One node per warm runner, billed
+  continuously (recommendation: 2).
+- **maxRunners**: Maximum concurrent runners. Must not exceed the node pool's
+  `max_nodes`, or the surplus runners sit `Pending` forever.
+- **runner resources**: Memory for work run *directly* on the runner (npm, jest,
+  pytest, go build).
+- **dind resources**: Memory for work run *inside Docker* (`docker build`,
+  compose, testcontainers). These are separate budgets - an OOM names which
+  container overran.
+- **Image**: Custom runner image with pre-installed tools.
+- **Pull Secrets**: For accessing private registries.
+
+### Why the Docker sidecar is declared manually
+
+ARC's built-in `containerMode.type: "dind"` renders the Docker daemon sidecar
+from a hardcoded chart template with no `resources` field, and a user-supplied
+container named `dind` is filtered out of values. That leaves dockerd with no
+memory request and no memory limit, so every `docker build` competes for
+whatever node memory happens to be unreserved - the cause of intermittent,
+hard-to-attribute out-of-memory failures.
+
+Declaring the sidecar explicitly (the chart's "default" container mode) is the
+only way to give dockerd a memory reservation. The spec in
+`deploy/dind-values.yaml` reproduces exactly what `containerMode: "dind"`
+generated, plus resources and a pinned image.
+
+**On chart upgrades, re-render and diff the pod spec**, because we now own
+pieces the chart used to manage:
+
+```bash
+helm template redducklabs-runners \
+  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
+  --version <version> --kube-version <cluster-version> \
+  -f deploy/dind-values.yaml
+```
+
+### Capacity model
+
+One runner pod is scheduled per node: the pod requests 10Gi of memory
+(runner 5Gi + dind 5Gi) against ~13.32Gi of node allocatable, so two pods cannot
+share a node. Concurrency is therefore bounded by the node pool's `max_nodes` as
+well as by `maxRunners`, and the two must be changed together.
+
+See `docs/runbooks/node-pool-sizing.md`.
 
 ## 🧪 Testing Setup
 

--- a/docs/runbooks/node-pool-sizing.md
+++ b/docs/runbooks/node-pool-sizing.md
@@ -1,0 +1,185 @@
+# Runbook: Runner Node Pool Sizing
+
+How to change how many GitHub Actions runners can run concurrently, and how much
+memory each one gets.
+
+- **Cluster:** `redducklabs-cluster` (context `do-sfo3-redducklabs-cluster`, region sfo3)
+- **Pool:** `github-runners-pool-16g`
+- **Node size:** `s-8vcpu-16gb` — 8 vCPU, 16 GB, **$96/node/month**
+- **Pool labels/taints:** `node-type=github-runner`, `workload-type=ci-cd`,
+  taint `github-runner=true:NoSchedule`
+
+## The invariant: one runner pod per node
+
+This is the single most important thing to understand before changing anything.
+
+The runner pod requests `5Gi` (runner container) + `5Gi` (dind sidecar) = **10Gi
+of memory requests**. Node allocatable is **13.32Gi**. Two pods would need 20Gi,
+so the scheduler can only ever fit **one runner pod per node**, and the
+cluster-autoscaler adds a node for each additional concurrent job.
+
+That is deliberate. It is what stops one job's `docker build` from starving a
+neighbouring job's, which was the cause of the intermittent out-of-memory
+failures this design replaced.
+
+It means the pool bounds and the scale set bounds are coupled:
+
+```
+min_nodes >= minRunners        max_nodes >= maxRunners
+```
+
+`deploy/dind-values.yaml` is the source of truth for `minRunners`/`maxRunners`.
+The sizing workflow refuses to apply bounds that violate the invariant.
+
+## Current configuration
+
+| Setting | Value | Where it lives |
+|---|---|---|
+| `minRunners` | 2 | `deploy/dind-values.yaml` |
+| `maxRunners` | 8 | `deploy/dind-values.yaml` |
+| `min_nodes` | 2 | node pool (applied by the workflow below) |
+| `max_nodes` | 8 | node pool (applied by the workflow below) |
+| Per job | ~12.5Gi usable, 8 vCPU | `deploy/dind-values.yaml` resources |
+
+**Cost floor: $192/month** (2 nodes always running).
+**Cost ceiling: $768/month** (8 nodes, only while 8 jobs run concurrently).
+
+## Changing concurrency
+
+Concurrency is capped by `maxRunners` *and* by `max_nodes`. Raising one without
+the other does nothing useful — the extra runners just sit `Pending`.
+
+### 1. Change the scale set bounds
+
+Edit `deploy/dind-values.yaml`:
+
+```yaml
+minRunners: 2
+maxRunners: 8
+```
+
+Commit and open a PR. Then deploy via the **Deploy GitHub Runners** workflow
+(`.github/workflows/deploy-runners.yml`), setting `min_runners`/`max_runners` to
+the same numbers.
+
+### 2. Change the pool bounds
+
+Run the **Node Pool Sizing** workflow
+(`.github/workflows/node-pool-sizing.yml`):
+
+```
+Actions -> Node Pool Sizing -> Run workflow
+  min_nodes: 2
+  max_nodes: 8
+  pool_name: github-runners-pool-16g
+  apply:     (leave unchecked for a dry run first)
+```
+
+Run it once with `apply` unchecked to see the before/after, then again with
+`apply` checked. The workflow validates the inputs against
+`deploy/dind-values.yaml`, applies the change, and then verifies that
+autoscaling is still enabled and that the pool's labels and taints survived.
+
+### Fallback: apply by hand
+
+Only if the workflow is unavailable. Read the DigitalOcean guidance in the
+project instructions before mutating production by hand.
+
+```bash
+CLUSTER_ID=$(doctl kubernetes cluster list -o json \
+  | jq -r '.[] | select(.name=="redducklabs-cluster") | .id')
+
+POOL_ID=$(doctl kubernetes cluster node-pool list "$CLUSTER_ID" -o json \
+  | jq -r '.[] | select(.name=="github-runners-pool-16g") | .id')
+
+# --auto-scale MUST be passed. Omitting it can clear autoscaling and pin the
+# pool to a fixed node count.
+doctl kubernetes cluster node-pool update "$CLUSTER_ID" "$POOL_ID" \
+  --auto-scale --min-nodes 2 --max-nodes 8
+
+# Verify, including that labels and taints survived
+doctl kubernetes cluster node-pool list "$CLUSTER_ID" -o json \
+  | jq '.[] | select(.name=="github-runners-pool-16g")
+        | {auto_scale, min_nodes, max_nodes, count, labels, taints}'
+```
+
+If the label `node-type=github-runner` or the taint `github-runner=true:NoSchedule`
+is missing after an update, **fix it immediately** — without them, runner pods
+cannot schedule onto the pool, and production workloads can schedule onto it.
+
+## Changing memory per job
+
+Per-job memory is set by the `resources` blocks in `deploy/dind-values.yaml`:
+
+- `runner` container — memory for work run **directly** on the runner
+  (npm, jest, webpack, pytest, go build).
+- `dind` sidecar — memory for everything run **inside Docker**
+  (`docker build`, compose, testcontainers).
+
+Both are capped at `10Gi` with `5Gi` requested. The requests are what force one
+pod per node; the limits are what a job can actually consume.
+
+**Before raising a limit**, check which container is actually running out — see
+"Diagnosing an OOM" below. Raising the wrong one changes nothing.
+
+**Before raising the requests**, note the budget: node allocatable is 13.32Gi and
+system DaemonSets take ~0.68Gi, leaving **~12.64Gi**. Total requests must stay
+comfortably under that or pods stop scheduling entirely.
+
+To go beyond ~12.5Gi per job you need a bigger node size, which is a pool
+replacement, not a resize. `m-8vcpu-64gb` ($336/mo) is the cheapest memory on
+DigitalOcean at $5.25/GB.
+
+## Diagnosing an OOM
+
+Both containers now have explicit memory limits, so **an OOM names the container
+that overran**:
+
+- `runner` OOMKilled → the job process itself. Raise the `runner` limit, or
+  lower the job's own concurrency (e.g. Jest `--maxWorkers`).
+- `dind` OOMKilled → a Docker build. Raise the `dind` limit.
+
+```bash
+kubectl config use-context do-sfo3-redducklabs-cluster
+
+# Live memory use per container
+kubectl top pods -n arc-runners --containers
+
+# Node headroom
+kubectl top nodes
+
+# OOM kills and evictions (runner pods are ephemeral, so check promptly)
+kubectl get events -n arc-runners --sort-by=.lastTimestamp \
+  | grep -Ei 'oom|evict'
+```
+
+The scheduled **Runner Status** workflow also reports OOMKilled and evicted
+runners plus node memory headroom on every run.
+
+`kubectl top` depends on metrics-server, which is deployed by the
+**Deploy Cluster Addons** workflow (`.github/workflows/deploy-cluster-addons.yml`).
+
+## Trade-offs when tuning
+
+| Change | Effect | Cost |
+|---|---|---|
+| Raise `max_nodes` + `maxRunners` | More concurrent jobs | Ceiling only; you pay per node actually running |
+| Raise `min_nodes` + `minRunners` | Less queueing — jobs start without waiting for a node | **Floor**; billed continuously |
+| Raise container limits | More memory per job | Free until it forces a bigger node size |
+| Bigger node size | More memory per job | Pool replacement; per-node price change |
+
+The latency trade-off is worth stating plainly: at one pod per node, **any job
+beyond the warm pool waits for DigitalOcean to provision a node and pull the
+~1.34GB runner image.** `minRunners`/`min_nodes` is the dial that buys that
+latency away with money. Raise it if queueing hurts more than the bill.
+
+## Rollback
+
+Re-run the **Node Pool Sizing** workflow with the previous bounds. The pool is
+autoscaled, so lowering `max_nodes` does not destroy running jobs — the
+autoscaler drains surplus nodes as jobs finish. Lowering `min_nodes` takes
+effect once nodes go idle.
+
+If you need to stop everything, use the **Emergency Stop** workflow rather than
+resizing the pool to zero; DigitalOcean autoscaling pools cannot scale below one
+node.

--- a/docs/specs/2026-08-19-runner-capacity-and-memory-design.md
+++ b/docs/specs/2026-08-19-runner-capacity-and-memory-design.md
@@ -1,0 +1,178 @@
+# Runner Capacity and Memory Design
+
+**Date:** 2026-08-19
+**Status:** Implemented
+**Scope:** Runner concurrency ceiling, per-job memory, and OOM attribution.
+
+Toolchain and chart version upgrades are explicitly **out of scope** and are
+tracked as separate work.
+
+## Problem
+
+Two symptoms, reported together:
+
+1. Frequent "low memory" failures in CI jobs.
+2. Not enough runners - jobs queued behind a concurrency ceiling.
+
+## Diagnosis
+
+Measured against the live cluster (`do-sfo3-redducklabs-cluster`,
+pool `github-runners-pool-16g`, `s-8vcpu-16gb`):
+
+| | Before |
+|---|---|
+| Node allocatable | 13.32 GiB, 7880m CPU |
+| System pod memory requests | ~0.68 GiB |
+| `runner` container | requests 5Gi, limits 6Gi / 3 CPU |
+| `dind` sidecar | **no requests, no limits** |
+| Pods per node | 2 |
+| Node memory requests | 10934Mi (80% of allocatable) |
+| Scale set | `minRunners: 2`, `maxRunners: 6` - observed saturated at 6/6 |
+| Node pool | autoscaling 1-4 nodes |
+
+### There were two distinct failure mechanisms
+
+**1. The runner container's hard cap.** Work run directly on the runner (npm,
+jest, webpack, pytest, go build) hit the 6Gi cgroup limit and was cleanly
+OOMKilled.
+
+**2. The unbounded Docker daemon - the dominant cause.** Everything run inside
+Docker (`docker build`, compose, testcontainers) is charged to the `dind`
+sidecar, which had **no memory request and no memory limit**. Per node, two
+runner pods reserved 10Gi of 13.32Gi and system pods took ~0.68Gi, leaving
+**~2.6 GiB unreserved, shared between both nodes' Docker daemons**.
+
+A Docker build's available memory therefore depended on what the *other* runner
+on the same node happened to be doing, and because `dind` requested nothing it
+was the first candidate for the kernel OOM killer. That non-determinism is why
+the failures felt constant and could not be attributed to any one job.
+
+Critically: **raising the runner limit alone would have made mechanism 2 worse**,
+by reserving more of the node and starving `dind` further.
+
+### Concurrency was also under-provisioned twice over
+
+`maxRunners: 6` against a pool that could already provision 4 nodes x 2 pods =
+8 runner slots. Two slots were unused at zero cost.
+
+## Constraint discovered
+
+ARC's `containerMode.type: "dind"` renders the Docker sidecar from a **hardcoded
+chart template with no `resources` field**, and a user-supplied container named
+`dind` is explicitly filtered out of values by the
+`gha-runner-scale-set.non-runner-non-dind-containers` helper.
+
+Verified in chart **0.12.1** (deployed) and **0.14.2** (current). There is no
+values-level way to give the Docker daemon a memory reservation while
+`containerMode.type: "dind"` is set.
+
+## Decision
+
+Drop `containerMode.type: "dind"` and declare the Docker sidecar explicitly in
+`template.spec.initContainers` (the chart's "default" container mode, which
+renders `initContainers`, `containers` and `volumes` verbatim). This is the only
+mechanism that permits `resources` on the daemon.
+
+### Resulting configuration
+
+| | Requests | Limits |
+|---|---|---|
+| `runner` | 5Gi, 2 CPU | 10Gi, no CPU limit |
+| `dind` | 5Gi, 1 CPU | 10Gi, no CPU limit |
+
+| | Before | After |
+|---|---|---|
+| Concurrent runners | 6 | **8** |
+| Pods per node | 2 | **1** |
+| Memory per job | 6Gi hard cap + ~2.6Gi contended | **~12.5Gi across two reserved budgets** |
+| CPU per job | 3 of 8 vCPU | **8 vCPU** |
+| Node pool bounds | 1-4 nodes | **2-8 nodes** |
+| Cost floor / ceiling | $96 / $384 per month | **$192 / $768 per month** |
+
+### Rationale for the specific numbers
+
+**Requests of 5Gi + 5Gi = 10Gi** force exactly one pod per node: two pods would
+require 20Gi against 13.32Gi allocatable. One pod per node is the structural fix
+- it removes the noisy neighbour entirely rather than merely bounding it.
+
+Requests were deliberately set *below* the ~12.64Gi available budget rather than
+at it. 6Gi + 6Gi would have left only ~0.64Gi of slack, so a single additional
+DaemonSet could block scheduling. Since one-pod-per-node is already guaranteed
+by anything above 6.32Gi total, the extra reservation would buy nothing.
+
+**Limits of 10Gi + 10Gi are intentionally overcommitted** against the ~12.64Gi
+node budget. This lets a runner-heavy job use ~10Gi on the runner while dockerd
+idles, and a Docker-heavy job do the reverse. With one pod per node, the only
+workload exposed to that overcommit is the job itself.
+
+**No CPU limit.** With one pod per node there is nothing to protect, and the
+previous 3-CPU limit throttled builds to 3 of 8 available cores.
+
+### OOM attribution
+
+Because both containers now carry explicit limits, an OOM kill names the
+container that overran: `runner` means the job process, `dind` means a Docker
+build. This was the specific requirement, as the dominant failure mode was not
+known in advance.
+
+## Alternatives considered
+
+| Option | Outcome | Why not |
+|---|---|---|
+| **A.** 2 pods/node with an explicit dind reservation, pool to 8 nodes | 12 concurrent x ~6Gi | Same cost ceiling as the chosen option but bounds contention rather than removing it, and only marginally raises per-job memory |
+| **C.** Move to `m-8vcpu-64gb` ($336/mo, cheapest RAM on DigitalOcean at $5.25/GB), 4 pods/node | 12 concurrent x ~14Gi | Higher ceiling ($1008/mo) and only 2 vCPU per job |
+| **D.** Tiered pools with an opt-in `-xl` scale set | Varies | Best only if a small, known set of workflows are the memory hogs; that was not established |
+| Raise the runner limit only | - | Does not address the dominant failure mode, and worsens it by starving dind further |
+| `g-8vcpu-32gb` | - | $7.88/GB, strictly dominated by both `s-8vcpu-16gb` ($6/GB) and `m-8vcpu-64gb` ($5.25/GB) |
+
+## Supporting changes
+
+- **metrics-server deployed.** It was absent, so `kubectl top` did not work and
+  there was no memory visibility at all. Verified serving with TLS verification
+  fully enabled - `--kubelet-insecure-tls` is **not** required on this DOKS
+  cluster and is deliberately not set.
+- **Node pool sizing moved into code.** The pool's bounds previously existed
+  only as a comment while the real values were set by hand. Now applied by
+  `.github/workflows/node-pool-sizing.yml`, which validates the bounds against
+  `deploy/dind-values.yaml` and verifies that pool labels and taints survive.
+- **Capacity drift detection.** `deploy-runners.yml` and `runner-status.yml`
+  both warn when `maxRunners` exceeds the pool's `max_nodes`, which would
+  otherwise leave runners `Pending` with no obvious cause.
+- **`docker:dind` pinned** to `docker:29.7.2-dind`. The chart used a floating
+  tag; 29.7.2 is what it already resolved to, so this is a reproducibility fix
+  and not a behavioural change.
+
+## Verification performed
+
+- Rendered `deploy/dind-values.yaml` with `helm template` (chart 0.12.1,
+  `--kube-version 1.33.12`) and diffed the pod spec against a render of the
+  previous `containerMode: "dind"` configuration. The **only** differences are
+  the four intended ones: runner resources, dind resources, the pinned dind
+  image, and volume ordering. Environment variables, volume mounts,
+  `securityContext`, `startupProbe`, `serviceAccountName`, `restartPolicy`,
+  tolerations, `nodeSelector`, `imagePullSecrets` and the init container are
+  byte-identical, as is the set of rendered resource kinds.
+- Node pool resized and re-read: `auto_scale=true min=2 max=8`, labels and
+  taints intact.
+- metrics-server deployed and confirmed serving `kubectl top nodes` and
+  `kubectl top pods --containers`, both before and after applying the committed
+  values file. Rendered container args checked for duplicate flags.
+- YAML parse check across all workflows and values files; `bash -n` across all
+  scripts.
+
+## Known trade-off
+
+At one pod per node, **any job beyond the warm pool waits for DigitalOcean to
+provision a node and pull the ~1.34GB runner image**. Previously every second
+job landed on an already-running node. `minRunners`/`min_nodes` is the dial that
+buys that latency back with money; it is a one-line change in
+`deploy/dind-values.yaml` plus a **Node Pool Sizing** run.
+
+## Follow-up work (separate change)
+
+- ARC chart 0.12.1 -> 0.14.2 (controller and scale set). On upgrade, re-render
+  and re-diff the pod spec, since this design moves ownership of the dind
+  sidecar from the chart to this repository.
+- DOKS 1.33.12 -> 1.36.3. Note the `restartPolicy: Always` native sidecar
+  requires >= 1.29.
+- Dockerfile toolchain version sweep.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,13 +23,13 @@ Main scaling script with full control over runner count.
 # Check current status
 ./scale-runners.sh status
 
-# Scale to default (2 min, 4 max)
+# Scale to default (2 min, 8 max)
 ./scale-runners.sh up
 
 # Scale to zero for maintenance
 ./scale-runners.sh down
 
-# Scale to maximum capacity (4 min, 8 max)
+# Scale to maximum warm capacity (4 min, 8 max) - MIN is billed continuously
 ./scale-runners.sh max
 
 # Custom scaling

--- a/scripts/scale-runners.sh
+++ b/scripts/scale-runners.sh
@@ -7,7 +7,13 @@ set -e
 # Configuration for redducklabs
 NAMESPACE="arc-runners"
 RELEASE_NAME="redducklabs-runners"
-VALUES_FILE="../deploy/dind-values.yaml"
+CLUSTER_NAME="${CLUSTER_NAME:-redducklabs-cluster}"
+RUNNER_POOL_NAME="${RUNNER_POOL_NAME:-github-runners-pool-16g}"
+
+# One runner pod is scheduled per node (runner 5Gi + dind 5Gi of memory requests
+# exceed half of node allocatable), so concurrency is capped by the node pool's
+# max_nodes as well as by maxRunners. Scaling maxRunners above max_nodes just
+# leaves runners Pending. See docs/runbooks/node-pool-sizing.md.
 
 # Colors for output
 RED='\033[0;31m'
@@ -28,10 +34,10 @@ show_usage() {
     echo ""
     echo "Commands:"
     echo "  status          - Show current runner status"
-    echo "  scale MIN MAX   - Scale runners (e.g., scale 2 4)"
-    echo "  up              - Scale to default (2 min, 4 max)"
+    echo "  scale MIN MAX   - Scale runners (e.g., scale 2 8)"
+    echo "  up              - Scale to default (2 min, 8 max)"
     echo "  down            - Scale to zero (maintenance mode)"
-    echo "  max             - Scale to maximum capacity (4 min, 8 max)"
+    echo "  max             - Scale to maximum warm capacity (4 min, 8 max)"
     echo "  get             - Get current scaling configuration"
     echo ""
     echo "Examples:"
@@ -39,7 +45,12 @@ show_usage() {
     echo "  $0 scale 3 6    # Scale to 3 min, 6 max"
     echo "  $0 down         # Scale to zero for maintenance"
     echo "  $0 up           # Restore default scaling"
-    echo "  $0 max          # Maximum capacity"
+    echo "  $0 max          # Maximum warm capacity"
+    echo ""
+    echo "NOTE: one runner pod runs per node, so MAX above the pool's max_nodes"
+    echo "      leaves runners Pending, and MIN is billed continuously."
+    echo "      Pool bounds: .github/workflows/node-pool-sizing.yml"
+    echo "      Runbook:     docs/runbooks/node-pool-sizing.md"
     exit 1
 }
 
@@ -114,7 +125,34 @@ scale_runners() {
         print_error "MIN ($min_runners) cannot be greater than MAX ($max_runners)"
         exit 1
     fi
-    
+
+    # One runner pod per node: warn if the pool cannot physically hold MAX
+    # runners, or if MIN exceeds the warm node floor. Advisory only - doctl may
+    # not be configured, and this script should still work without it.
+    if command -v doctl &> /dev/null && command -v jq &> /dev/null; then
+        local pool_json
+        pool_json=$(doctl kubernetes cluster list -o json 2>/dev/null \
+            | jq -r --arg n "$CLUSTER_NAME" '.[] | select(.name==$n) | .id' 2>/dev/null \
+            | xargs -r -I{} doctl kubernetes cluster node-pool list {} -o json 2>/dev/null \
+            | jq -r --arg p "$RUNNER_POOL_NAME" '.[] | select(.name==$p)' 2>/dev/null)
+
+        if [ -n "$pool_json" ]; then
+            local pool_min pool_max
+            pool_min=$(echo "$pool_json" | jq -r '.min_nodes')
+            pool_max=$(echo "$pool_json" | jq -r '.max_nodes')
+
+            if [[ "$pool_max" =~ ^[0-9]+$ ]] && [ "$max_runners" -gt "$pool_max" ]; then
+                print_warning "MAX ($max_runners) exceeds pool max_nodes ($pool_max)."
+                print_warning "Runners above $pool_max will stay Pending - resize the pool first"
+                print_warning "with the 'Node Pool Sizing' workflow."
+            fi
+            if [[ "$pool_min" =~ ^[0-9]+$ ]] && [ "$min_runners" -gt "$pool_min" ]; then
+                print_warning "MIN ($min_runners) exceeds pool min_nodes ($pool_min)."
+                print_warning "Warm runners will wait on node provisioning until the pool scales up."
+            fi
+        fi
+    fi
+
     print_info "Scaling redducklabs runners to MIN=$min_runners, MAX=$max_runners..."
     
     helm upgrade "$RELEASE_NAME" \
@@ -152,14 +190,18 @@ scale_down() {
 }
 
 # Function to scale to default
+# Matches minRunners/maxRunners in deploy/dind-values.yaml.
 scale_up() {
-    print_info "Scaling redducklabs runners to default configuration (2 min, 4 max)..."
-    scale_runners 2 4
+    print_info "Scaling redducklabs runners to default configuration (2 min, 8 max)..."
+    scale_runners 2 8
 }
 
-# Function to scale to maximum
+# Function to scale to maximum warm capacity.
+# NOTE: MIN is billed continuously - one node per warm runner. 4 warm runners
+# means 4 nodes running around the clock. Use 'up' to return to the default.
 scale_max() {
-    print_info "Scaling redducklabs runners to maximum capacity (4 min, 8 max)..."
+    print_info "Scaling redducklabs runners to maximum warm capacity (4 min, 8 max)..."
+    print_warning "MIN=4 keeps 4 nodes running continuously. Run '$0 up' to revert."
     scale_runners 4 8
 }
 

--- a/test/verify-runner-resources.sh
+++ b/test/verify-runner-resources.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+
+# Verify the runner pod's memory reservations survive a chart render.
+#
+# Why this test exists: ARC's containerMode.type "dind" renders the Docker
+# daemon sidecar from a hardcoded chart template with NO resources field, and
+# silently FILTERS OUT any user-supplied container named "dind". Re-introducing
+# containerMode.type: "dind" would therefore drop the dind memory reservation
+# without any error, warning, or diff in the values file - and reintroduce the
+# intermittent out-of-memory failures this configuration exists to fix.
+#
+# This renders deploy/dind-values.yaml with Helm and asserts the invariants.
+# It needs helm, jq and network access to the chart registry; it does NOT need
+# cluster access.
+#
+# Usage: ./test/verify-runner-resources.sh
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+CHART="oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set"
+CHART_VERSION="${CHART_VERSION:-0.12.1}"
+KUBE_VERSION="${KUBE_VERSION:-1.33.12}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VALUES_FILE="${REPO_ROOT}/deploy/dind-values.yaml"
+
+# Node budget for github-runners-pool-16g (s-8vcpu-16gb).
+NODE_ALLOCATABLE_MI=13639     # 13967028Ki
+SYSTEM_OVERHEAD_MI=694        # cilium, kube-proxy, csi, do-node-agent
+
+FAILURES=0
+
+pass() { echo -e "${GREEN}✅ $1${NC}"; }
+fail() { echo -e "${RED}❌ $1${NC}"; FAILURES=$((FAILURES + 1)); }
+info() { echo -e "${YELLOW}$1${NC}"; }
+
+echo "======================================================"
+info "Runner Resource Reservation Verification"
+echo "======================================================"
+echo ""
+
+for tool in helm jq python; do
+    if ! command -v "$tool" &> /dev/null; then
+        echo -e "${RED}❌ Required tool not found: $tool${NC}"
+        exit 1
+    fi
+done
+
+if [ ! -f "$VALUES_FILE" ]; then
+    echo -e "${RED}❌ Values file not found: $VALUES_FILE${NC}"
+    exit 1
+fi
+
+# --- Static check on the values file -----------------------------------------
+info "Checking deploy/dind-values.yaml..."
+
+if grep -qE '^[[:space:]]*type:[[:space:]]*"?dind"?' "$VALUES_FILE" \
+   && grep -qE '^containerMode:' "$VALUES_FILE"; then
+    fail "containerMode.type: dind is set - this DROPS the dind resources block"
+    echo "   ARC filters out a user-supplied container named 'dind' when"
+    echo "   containerMode.type is 'dind', and renders its own with no limits."
+else
+    pass "containerMode.type is not set to dind"
+fi
+echo ""
+
+# --- Render the chart --------------------------------------------------------
+info "Rendering chart ${CHART_VERSION} (kube ${KUBE_VERSION})..."
+
+RENDER=$(helm template redducklabs-runners "$CHART" \
+    --version "$CHART_VERSION" \
+    --kube-version "$KUBE_VERSION" \
+    -f "$VALUES_FILE" \
+    --set githubConfigSecret.github_token=PLACEHOLDER \
+    --set controllerServiceAccount.name=arc-gha-rs-controller \
+    --set controllerServiceAccount.namespace=arc-systems 2>&1) || {
+        echo -e "${RED}❌ helm template failed${NC}"
+        echo "$RENDER" | tail -20
+        exit 1
+    }
+
+pass "Chart rendered successfully"
+echo ""
+
+# Convert the AutoscalingRunnerSet document to JSON for assertions.
+SPEC_JSON=$(printf '%s' "$RENDER" | python -c '
+import sys, yaml, json
+for doc in yaml.safe_load_all(sys.stdin):
+    if doc and doc.get("kind") == "AutoscalingRunnerSet":
+        print(json.dumps(doc))
+        break
+')
+
+if [ -z "$SPEC_JSON" ]; then
+    echo -e "${RED}❌ No AutoscalingRunnerSet found in rendered output${NC}"
+    exit 1
+fi
+
+# --- Assertions --------------------------------------------------------------
+info "Checking rendered pod spec..."
+
+mem_of() {  # container_name, list_path, field (requests|limits)
+    printf '%s' "$SPEC_JSON" | jq -r \
+        --arg n "$1" --arg f "$3" \
+        ".spec.template.spec.$2[]? | select(.name==\$n) | .resources[\$f].memory // \"\""
+}
+
+DIND_REQ=$(mem_of dind initContainers requests)
+DIND_LIM=$(mem_of dind initContainers limits)
+RUNNER_REQ=$(mem_of runner containers requests)
+RUNNER_LIM=$(mem_of runner containers limits)
+
+[ -n "$DIND_REQ" ] && pass "dind memory request:   $DIND_REQ" \
+                  || fail "dind has NO memory request - Docker builds will contend for unreserved node memory"
+[ -n "$DIND_LIM" ] && pass "dind memory limit:     $DIND_LIM" \
+                  || fail "dind has NO memory limit - a runaway Docker build can take down the node"
+[ -n "$RUNNER_REQ" ] && pass "runner memory request: $RUNNER_REQ" \
+                    || fail "runner has NO memory request"
+[ -n "$RUNNER_LIM" ] && pass "runner memory limit:   $RUNNER_LIM" \
+                    || fail "runner has NO memory limit"
+
+# dind must be a native sidecar, otherwise the runner starts before dockerd.
+DIND_RESTART=$(printf '%s' "$SPEC_JSON" | jq -r \
+    '.spec.template.spec.initContainers[]? | select(.name=="dind") | .restartPolicy // ""')
+[ "$DIND_RESTART" = "Always" ] \
+    && pass "dind runs as a native sidecar (restartPolicy: Always)" \
+    || fail "dind restartPolicy is '$DIND_RESTART', expected 'Always' (requires Kubernetes >= 1.29)"
+
+# The floating docker:dind tag silently changes the Docker version under builds.
+DIND_IMAGE=$(printf '%s' "$SPEC_JSON" | jq -r \
+    '.spec.template.spec.initContainers[]? | select(.name=="dind") | .image // ""')
+if [ "$DIND_IMAGE" = "docker:dind" ] || [ "$DIND_IMAGE" = "docker:latest" ]; then
+    fail "dind image '$DIND_IMAGE' is a floating tag - pin an explicit version"
+else
+    pass "dind image is pinned: $DIND_IMAGE"
+fi
+
+# DOCKER_HOST is injected automatically in dind mode but is OURS in default mode.
+DOCKER_HOST_SET=$(printf '%s' "$SPEC_JSON" | jq -r \
+    '[.spec.template.spec.containers[]? | select(.name=="runner") | .env[]? | select(.name=="DOCKER_HOST")] | length')
+[ "$DOCKER_HOST_SET" = "1" ] \
+    && pass "runner has DOCKER_HOST set" \
+    || fail "runner is missing DOCKER_HOST - it will not find the Docker daemon"
+echo ""
+
+# --- One pod per node --------------------------------------------------------
+info "Checking the one-pod-per-node invariant..."
+
+to_mi() {  # accepts Gi / Mi
+    case "$1" in
+        *Gi) python -c "print(int(float('${1%Gi}') * 1024))" ;;
+        *Mi) python -c "print(int(float('${1%Mi}')))" ;;
+        *)   echo 0 ;;
+    esac
+}
+
+REQ_TOTAL_MI=$(( $(to_mi "$DIND_REQ") + $(to_mi "$RUNNER_REQ") ))
+BUDGET_MI=$(( NODE_ALLOCATABLE_MI - SYSTEM_OVERHEAD_MI ))
+HALF_ALLOCATABLE_MI=$(( NODE_ALLOCATABLE_MI / 2 ))
+
+echo "  pod memory requests:  ${REQ_TOTAL_MI}Mi"
+echo "  node allocatable:     ${NODE_ALLOCATABLE_MI}Mi"
+echo "  usable after system:  ${BUDGET_MI}Mi"
+
+if [ "$REQ_TOTAL_MI" -gt "$HALF_ALLOCATABLE_MI" ]; then
+    pass "Requests exceed half of allocatable - exactly one runner pod per node"
+else
+    fail "Requests (${REQ_TOTAL_MI}Mi) allow two pods per node (half = ${HALF_ALLOCATABLE_MI}Mi)"
+    echo "   Two runner pods on a node reintroduces Docker-build contention."
+fi
+
+if [ "$REQ_TOTAL_MI" -le "$BUDGET_MI" ]; then
+    pass "Requests fit within the node budget (${REQ_TOTAL_MI}Mi <= ${BUDGET_MI}Mi)"
+else
+    fail "Requests (${REQ_TOTAL_MI}Mi) exceed the node budget (${BUDGET_MI}Mi) - pods will not schedule"
+fi
+echo ""
+
+# --- Scale set vs pool coupling ---------------------------------------------
+info "Checking scale set bounds..."
+MAXR=$(printf '%s' "$SPEC_JSON" | jq -r '.spec.maxRunners // 0')
+MINR=$(printf '%s' "$SPEC_JSON" | jq -r '.spec.minRunners // 0')
+echo "  minRunners=${MINR} maxRunners=${MAXR}"
+echo "  -> node pool must allow min_nodes >= ${MINR} and max_nodes >= ${MAXR}"
+echo "     (one runner pod per node; see docs/runbooks/node-pool-sizing.md)"
+echo ""
+
+echo "======================================================"
+if [ "$FAILURES" -eq 0 ]; then
+    echo -e "${GREEN}✅ All runner resource checks passed${NC}"
+    echo "======================================================"
+    exit 0
+else
+    echo -e "${RED}❌ ${FAILURES} check(s) failed${NC}"
+    echo "======================================================"
+    exit 1
+fi


### PR DESCRIPTION
## Problem

Two symptoms, one shared root cause plus a separate ceiling:

1. **Frequent \"low memory\" failures** in CI jobs.
2. **Not enough runners** — jobs queued behind `maxRunners: 6`, observed saturated at 6/6.

## Diagnosis

Measured against the live cluster:

| | Before |
|---|---|
| Node allocatable | 13.32 GiB, 7880m CPU |
| System pod requests | ~0.68 GiB |
| `runner` container | requests 5Gi, limits 6Gi / 3 CPU |
| `dind` sidecar | **no requests, no limits** |
| Pods per node | 2 |
| Node memory requests | 80% of allocatable |

There were **two distinct failure mechanisms**:

1. Work run directly on the runner hit the 6Gi cgroup cap → clean OOMKill.
2. Work run **inside Docker** is charged to the `dind` sidecar, which had **no memory request and no limit**. Two pods reserved 10Gi of 13.32Gi and system pods took ~0.68Gi, leaving **~2.6 GiB unreserved, shared between both Docker daemons**. A build's available memory depended on what the *neighbouring* runner was doing, and `dind` — requesting nothing — was first in line for the OOM killer.

Mechanism 2 was dominant, and explains why failures felt constant and unattributable. **Raising the runner limit alone would have made it worse**, by reserving more of the node and starving `dind` further.

## The constraint

ARC's `containerMode.type: "dind"` renders the daemon sidecar from a **hardcoded chart template with no `resources` field**, and explicitly filters out a user-supplied container named `dind`. Verified in chart **0.12.1** (deployed) and **0.14.2** (current). Declaring the sidecar ourselves is the only way to give dockerd a reservation.

## Changes

| | Before | After |
|---|---|---|
| Concurrent runners | 6 | **8** |
| Pods per node | 2 | **1** |
| Memory per job | 6Gi cap + ~2.6Gi contended | **~12.5Gi across two reserved budgets** |
| CPU per job | 3 of 8 vCPU | **8 vCPU** |
| Node pool | 1–4 nodes | **2–8 nodes** |
| Cost floor / ceiling | \$96 / \$384 per month | **\$192 / \$768 per month** |

Requests of 5Gi + 5Gi force exactly one pod per node, which *removes* the noisy neighbour rather than bounding it. Requests sit deliberately below the ~12.64Gi budget so system DaemonSets keep room; the limits are what a job can actually use.

Because both containers now carry explicit limits, **an OOM names the container that overran** — `runner` = the job process, `dind` = a Docker build.

### Supporting changes

- **Node pool sizing moved into code** (`node-pool-sizing.yml`). It previously existed only as a comment while real values were set by hand. The workflow validates bounds against `dind-values.yaml` and verifies pool labels/taints survive.
- **metrics-server added** (`deploy-cluster-addons.yml`). It was absent, so `kubectl top` did not work and there was no memory visibility at all. Verified serving with **TLS verification fully enabled** — `--kubelet-insecure-tls` is not needed here and is deliberately not set.
- **Capacity drift warnings** in `deploy-runners.yml` and `runner-status.yml` when `maxRunners` exceeds pool `max_nodes` (which would silently leave runners `Pending`).
- **`docker:dind` pinned** to `29.7.2-dind` — the version the floating tag already resolved to, so no behavioural change.
- **Corrected stale docs**: the Kubernetes floor is **1.29** (native sidecars), not 1.24; and a comment claiming runners block `sudo` was left over from a since-reverted change.

## Verification

- **`helm template` diff** of the new pod spec against a render of the previous `containerMode: dind` config: the **only** differences are the four intended ones. Env, volume mounts, `securityContext`, `startupProbe`, `serviceAccountName`, `restartPolicy`, tolerations, `nodeSelector`, `imagePullSecrets` and the init container are byte-identical, as is the set of rendered resource kinds.
- **New regression test** `test/verify-runner-resources.sh` (no cluster needed) — passes on the new config, and **confirmed to fail on the old one** on all four assertions.
- Node pool re-read after resize: `auto_scale=true min=2 max=8`, labels and taints intact.
- metrics-server confirmed serving `kubectl top` before and after applying the committed values; rendered args checked for duplicate flags.
- YAML parse check across all workflows/values; `bash -n` across all scripts.

## Already applied to the cluster

The node pool resize and metrics-server install were applied directly (authorized). **The pod spec change is NOT yet deployed** — that needs a **Deploy GitHub Runners** run, which will roll the runner fleet.

## Known trade-off

At one pod per node, jobs beyond the warm pool wait for a node to be provisioned and the ~1.34GB image pulled. `minRunners`/`min_nodes` trades money for that latency.

## Out of scope

ARC 0.12.1 → 0.14.2, DOKS 1.33 → 1.36, and the Dockerfile toolchain sweep — deliberately deferred to a follow-up so a version bump can't be confused with this restructure.

Design: `docs/specs/2026-08-19-runner-capacity-and-memory-design.md`
Runbook: `docs/runbooks/node-pool-sizing.md`