### PR TITLE
fix: use the correct ARC pod label selector

### DIFF
--- a/.github/workflows/deploy-runners.yml
+++ b/.github/workflows/deploy-runners.yml
@@ -398,7 +398,7 @@ jobs:
           
           echo ""
           echo "📊 Runner pods:"
-          kubectl get pods -n "${NAMESPACE}" -l runner-deployment-name="${RELEASE_NAME}"
+          kubectl get pods -n "${NAMESPACE}" -l actions.github.com/scale-set-name="${RELEASE_NAME}"
           
           echo ""
           echo "📈 Runner scale set:"

--- a/.github/workflows/emergency-stop.yml
+++ b/.github/workflows/emergency-stop.yml
@@ -188,7 +188,7 @@ jobs:
           echo "current_max=${CURRENT_MAX}" >> $GITHUB_OUTPUT
           
           # Count running pods
-          POD_COUNT=$(kubectl get pods -n "${NAMESPACE}" -l runner-deployment-name="${RELEASE_NAME}" --no-headers 2>/dev/null | wc -l)
+          POD_COUNT=$(kubectl get pods -n "${NAMESPACE}" -l actions.github.com/scale-set-name="${RELEASE_NAME}" --no-headers 2>/dev/null | wc -l)
           echo "pod_count=${POD_COUNT}" >> $GITHUB_OUTPUT
           
           echo "Current state saved:"
@@ -238,7 +238,7 @@ jobs:
           echo "Waiting for pods to terminate..."
           timeout=60
           while [ $timeout -gt 0 ]; do
-            REMAINING=$(kubectl get pods -n "${NAMESPACE}" -l runner-deployment-name="${RELEASE_NAME}" --no-headers 2>/dev/null | wc -l)
+            REMAINING=$(kubectl get pods -n "${NAMESPACE}" -l actions.github.com/scale-set-name="${RELEASE_NAME}" --no-headers 2>/dev/null | wc -l)
             
             if [ "${REMAINING}" -eq 0 ]; then
               echo "✅ All runner pods have been terminated"
@@ -251,14 +251,14 @@ jobs:
           done
           
           # Final check
-          FINAL_COUNT=$(kubectl get pods -n "${NAMESPACE}" -l runner-deployment-name="${RELEASE_NAME}" --no-headers 2>/dev/null | wc -l)
+          FINAL_COUNT=$(kubectl get pods -n "${NAMESPACE}" -l actions.github.com/scale-set-name="${RELEASE_NAME}" --no-headers 2>/dev/null | wc -l)
           
           if [ "${FINAL_COUNT}" -eq 0 ]; then
             echo "✅ Emergency stop completed successfully"
           else
             echo "⚠️ Warning: ${FINAL_COUNT} pod(s) may still be terminating"
             echo "Pod status:"
-            kubectl get pods -n "${NAMESPACE}" -l runner-deployment-name="${RELEASE_NAME}" 2>/dev/null || true
+            kubectl get pods -n "${NAMESPACE}" -l actions.github.com/scale-set-name="${RELEASE_NAME}" 2>/dev/null || true
           fi
       
       - name: Handle non-existent deployment

--- a/.github/workflows/runner-status.yml
+++ b/.github/workflows/runner-status.yml
@@ -244,7 +244,7 @@ jobs:
           NAMESPACE="${{ needs.validate-inputs.outputs.namespace }}"
           
           # Get pod information with error handling
-          PODS_JSON=$(kubectl get pods -n "${NAMESPACE}" -l runner-deployment-name="${RELEASE_NAME}" -o json 2>/dev/null)
+          PODS_JSON=$(kubectl get pods -n "${NAMESPACE}" -l actions.github.com/scale-set-name="${RELEASE_NAME}" -o json 2>/dev/null)
           
           if [ $? -eq 0 ] && [ "${PODS_JSON}" != "" ]; then
             TOTAL_PODS=$(echo "${PODS_JSON}" | jq '.items | length')
@@ -280,7 +280,7 @@ jobs:
           if [ "${{ needs.validate-inputs.outputs.detailed }}" = "true" ] && [ "${TOTAL_PODS}" -gt 0 ]; then
             echo ""
             echo "Pod Details:"
-            kubectl get pods -n "${NAMESPACE}" -l runner-deployment-name="${RELEASE_NAME}" 2>/dev/null || echo "Could not retrieve pod details"
+            kubectl get pods -n "${NAMESPACE}" -l actions.github.com/scale-set-name="${RELEASE_NAME}" 2>/dev/null || echo "Could not retrieve pod details"
           fi
 
       - name: Check memory headroom and OOM kills
@@ -462,7 +462,7 @@ jobs:
           NAMESPACE="${{ needs.validate-inputs.outputs.namespace }}"
           
           echo "Pod resource usage:"
-          kubectl top pods -n "${NAMESPACE}" -l runner-deployment-name="${RELEASE_NAME}" 2>/dev/null || echo "⚠️ Metrics server not available or no pods found"
+          kubectl top pods -n "${NAMESPACE}" -l actions.github.com/scale-set-name="${RELEASE_NAME}" 2>/dev/null || echo "⚠️ Metrics server not available or no pods found"
       
       - name: Generate status report
         if: always()

--- a/.github/workflows/scale-runners.yml
+++ b/.github/workflows/scale-runners.yml
@@ -222,7 +222,7 @@ jobs:
           echo "  Max runners: ${CURRENT_MAX}"
           
           # Get pod count
-          POD_COUNT=$(kubectl get pods -n "${NAMESPACE}" -l runner-deployment-name="${RELEASE_NAME}" --no-headers 2>/dev/null | wc -l)
+          POD_COUNT=$(kubectl get pods -n "${NAMESPACE}" -l actions.github.com/scale-set-name="${RELEASE_NAME}" --no-headers 2>/dev/null | wc -l)
           echo "pod_count=${POD_COUNT}" >> $GITHUB_OUTPUT
           echo "  Active pods: ${POD_COUNT}"
       
@@ -242,7 +242,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Pod Details" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          kubectl get pods -n "${NAMESPACE}" -l runner-deployment-name="${RELEASE_NAME}" >> $GITHUB_STEP_SUMMARY
+          kubectl get pods -n "${NAMESPACE}" -l actions.github.com/scale-set-name="${RELEASE_NAME}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
       
       - name: Scale up (default)
@@ -385,7 +385,7 @@ jobs:
           NAMESPACE="${{ needs.validate-inputs.outputs.namespace }}"
           
           echo "📊 New runner status:"
-          kubectl get pods -n "${NAMESPACE}" -l runner-deployment-name="${RELEASE_NAME}"
+          kubectl get pods -n "${NAMESPACE}" -l actions.github.com/scale-set-name="${RELEASE_NAME}"
           
           # Get new values with error handling
           NEW_VALUES=$(helm get values "${RELEASE_NAME}" -n "${NAMESPACE}" -o json 2>/dev/null)

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -117,6 +117,30 @@ jobs:
           chmod +x test/verify-runner-resources.sh
           ./test/verify-runner-resources.sh
 
+      - name: Check runner pod label selectors
+        run: |
+          echo "🔍 Checking for stale ARC pod label selectors..."
+          # ARC's gha-runner-scale-set labels runner pods with
+          # actions.github.com/scale-set-name. The legacy labels
+          # runner-deployment-name and runner-scale-set-name match NOTHING on a
+          # modern scale set, and kubectl exits 0 with an empty result - so a
+          # wrong selector fails silently. That previously made runner-status
+          # report "0 pods" with runners live, made emergency-stop's pod
+          # deletion a no-op while reporting success, and would have made the
+          # documented NetworkPolicy examples select no pods at all.
+          # --exclude this file: it necessarily names the legacy labels in its
+          # own comment and grep pattern, and would otherwise match itself.
+          if grep -rn --exclude-dir=.git --exclude=validate-config.yml \
+               -e 'runner-deployment-name' \
+               -e '[^./]runner-scale-set-name' \
+               .github/ scripts/ test/ docs/ 2>/dev/null | grep -v 'runnerScaleSetName'; then
+            echo ""
+            echo "❌ Stale runner pod label selector found (shown above)."
+            echo "   Use: actions.github.com/scale-set-name=<release>"
+            exit 1
+          fi
+          echo "✅ No stale runner pod label selectors"
+
       - name: Check for secrets in tracked files
         run: |
           echo "🔍 Checking that no token-like values were committed..."

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -116,7 +116,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      runner-scale-set-name: redducklabs-runners
+      actions.github.com/scale-set-name: redducklabs-runners
   policyTypes:
   - Egress
   egress:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -403,7 +403,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      runner-scale-set-name: redducklabs-runners
+      actions.github.com/scale-set-name: redducklabs-runners
   policyTypes:
   - Ingress
   - Egress

--- a/scripts/emergency-stop.sh
+++ b/scripts/emergency-stop.sh
@@ -50,17 +50,17 @@ helm upgrade redducklabs-runners \
 
 # Force delete all runner pods
 echo "2. Force deleting all redducklabs runner pods..."
-kubectl delete pods -n arc-runners -l runner-scale-set-name=redducklabs-runners --force --grace-period=0 2>/dev/null || true
+kubectl delete pods -n arc-runners -l actions.github.com/scale-set-name=redducklabs-runners --force --grace-period=0 2>/dev/null || true
 
 # Check if any pods remain
 echo "3. Checking for remaining pods..."
-remaining=$(kubectl get pods -n arc-runners -l runner-scale-set-name=redducklabs-runners --no-headers 2>/dev/null | wc -l)
+remaining=$(kubectl get pods -n arc-runners -l actions.github.com/scale-set-name=redducklabs-runners --no-headers 2>/dev/null | wc -l)
 
 if [ "$remaining" -gt 0 ]; then
     echo -e "${YELLOW}Warning: $remaining pods still terminating${NC}"
     echo "Waiting for termination to complete..."
     sleep 10
-    remaining=$(kubectl get pods -n arc-runners -l runner-scale-set-name=redducklabs-runners --no-headers 2>/dev/null | wc -l)
+    remaining=$(kubectl get pods -n arc-runners -l actions.github.com/scale-set-name=redducklabs-runners --no-headers 2>/dev/null | wc -l)
     if [ "$remaining" -gt 0 ]; then
         echo -e "${YELLOW}$remaining pods still terminating - they will finish shortly${NC}"
     fi

--- a/scripts/runner-admin.sh
+++ b/scripts/runner-admin.sh
@@ -35,7 +35,7 @@ show_menu() {
 
 check_status() {
     echo -e "${BLUE}Current Status:${NC}"
-    kubectl get pods -n "$NAMESPACE" -l runner-scale-set-name="$RELEASE_NAME"
+    kubectl get pods -n "$NAMESPACE" -l actions.github.com/scale-set-name="$RELEASE_NAME"
     echo ""
     kubectl get autoscalingrunnersets -n "$NAMESPACE" "$RELEASE_NAME"
 }
@@ -69,7 +69,7 @@ restart_all() {
     read -r response
     
     if [[ "$response" =~ ^[Yy]$ ]]; then
-        kubectl delete pods -n "$NAMESPACE" -l runner-scale-set-name="$RELEASE_NAME"
+        kubectl delete pods -n "$NAMESPACE" -l actions.github.com/scale-set-name="$RELEASE_NAME"
         echo "Pods deleted. New ones will be created automatically."
         sleep 5
         check_status
@@ -80,11 +80,11 @@ restart_all() {
 
 view_logs() {
     echo "Available runner pods:"
-    kubectl get pods -n "$NAMESPACE" -l runner-scale-set-name="$RELEASE_NAME" --no-headers | awk '{print NR") " $1 " (" $3 ")"}'
+    kubectl get pods -n "$NAMESPACE" -l actions.github.com/scale-set-name="$RELEASE_NAME" --no-headers | awk '{print NR") " $1 " (" $3 ")"}'
     echo -n "Enter number: "
     read num
     
-    pod=$(kubectl get pods -n "$NAMESPACE" -l runner-scale-set-name="$RELEASE_NAME" --no-headers | awk "NR==$num {print \$1}")
+    pod=$(kubectl get pods -n "$NAMESPACE" -l actions.github.com/scale-set-name="$RELEASE_NAME" --no-headers | awk "NR==$num {print \$1}")
     if [ -n "$pod" ]; then
         echo -e "${BLUE}Logs for $pod:${NC}"
         kubectl logs -n "$NAMESPACE" "$pod" -c runner --tail=100

--- a/scripts/scale-runners.sh
+++ b/scripts/scale-runners.sh
@@ -95,7 +95,7 @@ get_status() {
     
     # Get pod status
     echo "Runner Pods:"
-    kubectl get pods -n "$NAMESPACE" -l runner-scale-set-name="$RELEASE_NAME" 2>/dev/null || echo "No runner pods found"
+    kubectl get pods -n "$NAMESPACE" -l actions.github.com/scale-set-name="$RELEASE_NAME" 2>/dev/null || echo "No runner pods found"
     echo ""
     
     # Get GitHub registration status

--- a/test/README.md
+++ b/test/README.md
@@ -55,7 +55,7 @@ Before running tests, ensure:
 
 2. **Runners are deployed:**
    ```bash
-   kubectl get pods -n arc-runners -l runner-scale-set-name=redducklabs-runners
+   kubectl get pods -n arc-runners -l actions.github.com/scale-set-name=redducklabs-runners
    ```
 
 3. **Required tools on local machine:**
@@ -93,7 +93,7 @@ All tests use color-coded output:
 kubectl get pods -n arc-runners
 
 # Check runner scale set
-kubectl get pods -n arc-runners -l runner-scale-set-name=redducklabs-runners
+kubectl get pods -n arc-runners -l actions.github.com/scale-set-name=redducklabs-runners
 
 # If no pods exist, deploy runners first
 cd deploy && ./deploy.sh

--- a/test/test-deployment.sh
+++ b/test/test-deployment.sh
@@ -110,7 +110,7 @@ echo ""
 print_header "4. Pod Status Check"
 
 # Get runner pods
-pods=$(kubectl get pods -n "$NAMESPACE" -l runner-scale-set-name="$RELEASE_NAME" --no-headers 2>/dev/null || true)
+pods=$(kubectl get pods -n "$NAMESPACE" -l actions.github.com/scale-set-name="$RELEASE_NAME" --no-headers 2>/dev/null || true)
 
 if [ -z "$pods" ]; then
     print_warning "No runner pods found - this might be normal if minRunners=0"
@@ -204,7 +204,7 @@ print_header "7. Resource Usage Check"
 
 if [ "$pod_count" -gt 0 ]; then
     echo "Current resource usage:"
-    kubectl top pods -n "$NAMESPACE" -l runner-scale-set-name="$RELEASE_NAME" 2>/dev/null || print_warning "Metrics not available (metrics-server may not be installed)"
+    kubectl top pods -n "$NAMESPACE" -l actions.github.com/scale-set-name="$RELEASE_NAME" 2>/dev/null || print_warning "Metrics not available (metrics-server may not be installed)"
 fi
 
 echo ""

--- a/test/verify-security-fixes.sh
+++ b/test/verify-security-fixes.sh
@@ -16,7 +16,7 @@ echo "Verifying security fixes in redducklabs GitHub Actions runners..."
 echo "=================================================================="
 
 # Get a runner pod
-RUNNER_POD=$(kubectl get pods -n arc-runners -l runner-scale-set-name=redducklabs-runners --no-headers | head -1 | awk '{print $1}')
+RUNNER_POD=$(kubectl get pods -n arc-runners -l actions.github.com/scale-set-name=redducklabs-runners --no-headers | head -1 | awk '{print $1}')
 
 if [ -z "$RUNNER_POD" ]; then
     echo "Error: No redducklabs runner pods found!"

--- a/test/verify-tools.sh
+++ b/test/verify-tools.sh
@@ -7,7 +7,7 @@ echo "Verifying tools in redducklabs GitHub Actions runners..."
 echo "====================================================="
 
 # Get a runner pod
-RUNNER_POD=$(kubectl get pods -n arc-runners -l runner-scale-set-name=redducklabs-runners --no-headers | head -1 | awk '{print $1}')
+RUNNER_POD=$(kubectl get pods -n arc-runners -l actions.github.com/scale-set-name=redducklabs-runners --no-headers | head -1 | awk '{print $1}')
 
 if [ -z "$RUNNER_POD" ]; then
     echo "Error: No redducklabs runner pods found!"


### PR DESCRIPTION
## Summary

Every runner pod lookup in this repo used a label that **does not exist** on modern ARC runner pods. Found while verifying the new memory diagnostics from #23: `runner-status` reported `Total: 0` runner pods while 8 were live.

Verified against the live cluster (4 runner pods running at the time):

| Selector | Pods matched |
|---|---|
| `runner-deployment-name=redducklabs-runners` | **0** |
| `runner-scale-set-name=redducklabs-runners` | **0** |
| `actions.github.com/scale-set-name=redducklabs-runners` | **4** ✅ |

`kubectl` exits 0 with an empty result for a selector matching nothing, so **all of these failed silently** rather than erroring.

## Impact

| Where | Broken behaviour |
|---|---|
| **`emergency-stop.yml`** | Counted 0 pods → printed *"All runner pods have been terminated"* and *"Emergency stop completed successfully"* **immediately**, without confirming anything stopped. A false all-clear in the one workflow where that matters most. |
| **`scripts/emergency-stop.sh`** | Its `kubectl delete pods -l ...` force-delete **matched nothing and deleted nothing**, while reporting success. |
| **`runner-status.yml`** | Reported `Total: 0` pods with runners live; pod detail and `kubectl top` views always empty. |
| **`scale-runners.yml` / `deploy-runners.yml`** | Empty pod lists in every summary. |
| **`verify-tools.sh` / `verify-security-fixes.sh`** | Selected an empty pod name — they could not have been running against a real runner. |
| **`SECURITY.md` / `SETUP.md`** | NetworkPolicy examples used the stale label in `podSelector.matchLabels`, so applying them yields a policy selecting **no pods**, silently enforcing nothing. |

## Changes

- All 27 occurrences across workflows, scripts, tests and docs → `actions.github.com/scale-set-name`.
- **Static guard** added to `validate-config.yml` so a stale selector cannot come back.

## Verification

- Corrected selectors confirmed against the live cluster: 4/4 pods matched by `kubectl get`, `kubectl top`, and the pod-picking used by the test scripts.
- Guard tested **both directions**: passes on the clean tree, fails when a legacy selector is reintroduced, passes again after removal.
- YAML parse + `bash -n` across all changed files.

Follows #23.