### PR TITLE
ci: refresh CI tool pins and action versions

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -5,15 +5,27 @@ inputs:
   kubectl-version:
     description: 'kubectl version to install'
     required: false
-    default: 'v1.33.3'
+    # Tracks the DOKS CLUSTER minor, NOT the runner image's kubectl.
+    #
+    # This action is used only by this repo's own workflows (deploy-runners,
+    # deploy-cluster-addons, emergency-stop, node-pool-sizing, runner-status,
+    # scale-runners) -- all of which talk to the production cluster. Kubernetes
+    # supports kubectl within ONE minor of the API server, so this pin must stay
+    # on the cluster's minor. The cluster is 1.33.x, so this is 1.33.x.
+    #
+    # Do NOT "align" this with docker/Dockerfile.custom-runner's KUBECTL_VERSION.
+    # That one ships to consumer projects targeting arbitrary clusters, so it
+    # tracks latest; matching it here would put emergency-stop and deploy three
+    # minors outside the supported skew. Bump this when the cluster minor moves.
+    default: 'v1.33.13'
   helm-version:
     description: 'Helm version to install'
     required: false
-    default: 'v3.18.6'
+    default: 'v3.21.4'
   doctl-version:
     description: 'doctl version to install'
     required: false
-    default: 'v1.139.0'
+    default: 'v1.167.0'
   install-jq:
     description: 'Install jq package'
     required: false
@@ -67,7 +79,7 @@ runs:
         echo "Cache key: ${CACHE_KEY}"
 
     - name: Cache tools
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-tools
       with:
         path: |

--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Verify AWS signing key not expired (cache-independent)
         run: bash test/verify-aws-key-expiry.sh docker/aws-cli-public.key
@@ -222,7 +222,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Verify AWS signing key not expired (cache-independent)
         run: bash test/verify-aws-key-expiry.sh docker/aws-cli-public.key
@@ -329,7 +329,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Authenticate with DigitalOcean Registry (for Trivy)
         run: |

--- a/.github/workflows/deploy-cluster-addons.yml
+++ b/.github/workflows/deploy-cluster-addons.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup infrastructure tools
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/deploy-runners.yml
+++ b/.github/workflows/deploy-runners.yml
@@ -128,7 +128,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       
       - name: Setup infrastructure tools
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/emergency-stop.yml
+++ b/.github/workflows/emergency-stop.yml
@@ -95,7 +95,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       
       - name: Setup infrastructure tools
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/node-pool-sizing.yml
+++ b/.github/workflows/node-pool-sizing.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup infrastructure tools
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/runner-status.yml
+++ b/.github/workflows/runner-status.yml
@@ -88,7 +88,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       
       - name: Setup infrastructure tools
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/scale-runners.yml
+++ b/.github/workflows/scale-runners.yml
@@ -135,7 +135,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       
       - name: Setup infrastructure tools
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Validate YAML syntax
         run: |


### PR DESCRIPTION
First of the version-refresh workstream. Runtime-neutral: no runner image
rebuild, no cluster change. Verified against upstream on 2026-08-19.

## setup-tools

| Tool | Before | After |
|---|---|---|
| kubectl | v1.33.3 | v1.33.13 |
| Helm | v3.18.6 | v3.21.4 |
| doctl | v1.139.0 | v1.167.0 |

**kubectl deliberately stays on 1.33**, rather than matching the runner
image's `KUBECTL_VERSION=v1.36.1`. This action is used only by workflows that
talk to the production DOKS cluster (`deploy-runners`, `deploy-cluster-addons`,
`emergency-stop`, `node-pool-sizing`, `runner-status`, `scale-runners`).
Kubernetes supports kubectl within **one minor** of the API server; the cluster
is on 1.33.12. Matching the image pin would put deploy and emergency-stop three
minors outside the supported skew. The image pin serves a different purpose —
it ships to consumer projects targeting arbitrary clusters — so it tracks
latest. Rationale is recorded inline in `action.yml` so the two pins are not
"aligned" later by mistake.

**Helm stays on the 3.x line.** Helm 4.2.4 is out; moving the fleet to a Helm
major is a consumer-visible change and is deliberately not bundled here.
Confirmed `scripts/get-helm-3` still exists on `helm/helm@main`, still carries
the `HELM_INSTALL_DIR` guard the action tamper-checks, and still honours an
explicit `DESIRED_VERSION` (it only consults the `helm3-latest-version` CDN when
unset), so the Helm 4 release does not change this install path.

## Actions

- `actions/checkout` v6 → v7
- `actions/cache` v5 → v6

Both majors are ESM migrations. checkout v7 additionally blocks checking out
fork PR heads under `pull_request_target` / `workflow_run` — grepped, no
workflow in this repo uses either trigger.

## Verification

- All 9 workflows + the composite action parse as YAML locally
- `kubectl v1.33.13` sha256 endpoint, `helm-v3.21.4-linux-amd64.tar.gz`, and
  `doctl-1.167.0-checksums.sha256` all confirmed reachable, so the
  checksum-verified install paths resolve
- `validate-config.yml` (actionlint, shellcheck, invariants) gates this PR