### PR TITLE
chore: upgrade ARC chart to 0.14.2 and make the controller upgradable

### DIFF
--- a/.github/workflows/deploy-runners.yml
+++ b/.github/workflows/deploy-runners.yml
@@ -50,6 +50,12 @@ env:
   RUNNER_SCALE_SET_NAME: ${{ vars.RUNNER_SCALE_SET_NAME || 'redducklabs-runners' }}
   REGISTRY: ${{ vars.REGISTRY || 'registry.digitalocean.com' }}
   REPOSITORY: ${{ vars.REPOSITORY || 'redducklabs/github-runner' }}
+  # Single pin for BOTH ARC charts. The controller chart
+  # (gha-runner-scale-set-controller) and the scale set chart
+  # (gha-runner-scale-set) are released together and are expected to run at the
+  # same version, so they must not drift apart. Keep this in sync with
+  # CHART_VERSION in test/verify-runner-resources.sh.
+  ARC_CHART_VERSION: '0.14.2'
 
 # Use minimal permissions
 permissions:
@@ -292,15 +298,14 @@ jobs:
             echo "Registry secret already exists"
           fi
       
-      - name: Check for existing ARC controller
-        id: check-controller
+      - name: Report current ARC controller state
         run: |
           echo "🔍 Checking for Actions Runner Controller..."
-          
+
           if helm list -n arc-systems 2>/dev/null | grep -q arc; then
-            echo "controller_exists=true" >> $GITHUB_OUTPUT
-            echo "✅ ARC controller found"
-            
+            echo "✅ ARC controller release found"
+            helm list -n arc-systems || true
+
             # Check controller health
             if kubectl get pods -n arc-systems -l app.kubernetes.io/name=gha-rs-controller --no-headers | grep -q Running; then
               echo "✅ ARC controller is running"
@@ -308,46 +313,108 @@ jobs:
               echo "⚠️ ARC controller pods may not be ready"
             fi
           else
-            echo "controller_exists=false" >> $GITHUB_OUTPUT
-            echo "⚠️ ARC controller not found - will install"
+            echo "⚠️ ARC controller not found - will be installed"
           fi
-      
-      - name: Install ARC controller if needed
-        if: steps.check-controller.outputs.controller_exists == 'false'
+
+          echo ""
+          echo "Installed CRD generation (drifts from the chart because Helm"
+          echo "never updates crds/ on upgrade - the next step reconciles it):"
+          kubectl get crd autoscalingrunnersets.actions.github.com \
+            -o jsonpath='{.metadata.annotations.controller-gen\.kubebuilder\.io/version}' 2>/dev/null || echo "(CRD not installed yet)"
+          echo ""
+
+      - name: Sync ARC CRDs
         run: |
-          echo "📦 Installing Actions Runner Controller..."
-          
-          # Create namespace first
+          echo "📦 Reconciling ARC CRDs to chart ${ARC_CHART_VERSION}..."
+
+          # WHY THIS STEP EXISTS
+          #
+          # Helm installs a chart's crds/ directory exactly once, on first
+          # install, and NEVER touches it again on `helm upgrade`. That is
+          # documented Helm behaviour, not an ARC quirk. So every ARC chart
+          # upgrade silently leaves the CRDs at whatever generation they were
+          # first installed with, while the controller moves forward. The drift
+          # is invisible until a newer controller writes a field the stale CRD
+          # schema prunes.
+          #
+          # WHY --server-side
+          #
+          # These CRDs are 575 KB - 1.2 MB each (they embed a full PodSpec).
+          # Client-side `kubectl apply` stores the whole manifest in the
+          # kubectl.kubernetes.io/last-applied-configuration annotation, which
+          # is capped at 256 KB, so a plain apply FAILS on them. Server-side
+          # apply carries no such annotation. --force-conflicts takes ownership
+          # of fields whose current field manager is Helm's.
+          CRD_DIR="$(mktemp -d)"
+          helm pull \
+            oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller \
+            --version "${ARC_CHART_VERSION}" \
+            --untar --untardir "${CRD_DIR}"
+
+          CRD_PATH="${CRD_DIR}/gha-runner-scale-set-controller/crds"
+          if [ ! -d "${CRD_PATH}" ]; then
+            echo "❌ Error: no crds/ directory in chart ${ARC_CHART_VERSION}"
+            exit 1
+          fi
+
+          echo "CRDs to apply:"
+          ls -la "${CRD_PATH}"
+
+          kubectl apply --server-side --force-conflicts -f "${CRD_PATH}"
+
+          echo ""
+          echo "✅ CRDs reconciled. Generation now:"
+          kubectl get crd autoscalingrunnersets.actions.github.com \
+            -o jsonpath='{.metadata.annotations.controller-gen\.kubebuilder\.io/version}'
+          echo ""
+
+          rm -rf "${CRD_DIR}"
+
+      - name: Install or upgrade ARC controller
+        run: |
+          echo "📦 Installing/upgrading Actions Runner Controller to ${ARC_CHART_VERSION}..."
+
+          # `helm upgrade --install` (not bare `helm install` behind an
+          # existence check). The previous form only ran when the controller was
+          # ABSENT, which made the pinned chart version dead code on any cluster
+          # that already had ARC: the repo claimed one version while the cluster
+          # ran another, and the controller could never be upgraded through CI.
+          # This form is idempotent and expresses the desired end state, so the
+          # pin above is the single source of truth.
+          #
+          # The controller and scale set charts are released as a matched pair;
+          # both use ARC_CHART_VERSION so they cannot drift apart.
           kubectl create namespace arc-systems --dry-run=client -o yaml | kubectl apply -f -
-          
-          # Install with retry logic
+
           for attempt in 1 2 3; do
-            echo "Attempt ${attempt}/3: Installing ARC controller..."
-            if helm install arc \
+            echo "Attempt ${attempt}/3: Installing/upgrading ARC controller..."
+            if helm upgrade --install arc \
               --namespace arc-systems \
               --create-namespace \
               oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller \
-              --version 0.12.1 \
+              --version "${ARC_CHART_VERSION}" \
               --wait \
               --timeout 300s; then
-              
-              echo "✅ ARC controller installed successfully"
+
+              echo "✅ ARC controller at ${ARC_CHART_VERSION}"
               break
             elif [ "${attempt}" = "3" ]; then
-              echo "❌ Error: Failed to install ARC controller"
+              echo "❌ Error: Failed to install/upgrade ARC controller"
+              helm status arc -n arc-systems || true
+              kubectl get pods -n arc-systems || true
               exit 1
             else
-              echo "⚠️ Installation failed, retrying in 10s..."
+              echo "⚠️ Failed, retrying in 10s..."
               sleep 10
             fi
           done
-          
+
           echo "⏳ Waiting for controller to be ready..."
           kubectl wait --for=condition=ready pod \
             -l app.kubernetes.io/name=gha-rs-controller \
             -n arc-systems \
             --timeout=300s
-      
+
       - name: Deploy runners
         run: |
           echo "🚀 Deploying GitHub runners..."
@@ -373,7 +440,7 @@ jobs:
               --set minRunners="${MIN_RUNNERS}" \
               --set maxRunners="${MAX_RUNNERS}" \
               --set-string "template.spec.containers[0].image=${RUNNER_IMAGE}" \
-              --version 0.12.1 \
+              --version "${ARC_CHART_VERSION}" \
               --wait \
               --timeout 300s; then
 

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -117,6 +117,34 @@ jobs:
           chmod +x test/verify-runner-resources.sh
           ./test/verify-runner-resources.sh
 
+      - name: Check ARC chart version pins agree
+        run: |
+          echo "🔍 Checking ARC chart version pins..."
+          # Two places pin the ARC chart: the deploy workflow (which installs
+          # both the controller chart and the scale set chart) and the resource
+          # verifier (which renders the scale set chart offline). If they drift,
+          # the verifier proves invariants against a chart version the fleet
+          # does not actually run - the check passes and means nothing.
+          DEPLOY_VER="$(grep -oP "^\s*ARC_CHART_VERSION:\s*'\K[^']+" \
+            .github/workflows/deploy-runners.yml || true)"
+          TEST_VER="$(grep -oP '^CHART_VERSION="\$\{CHART_VERSION:-\K[^}]+' \
+            test/verify-runner-resources.sh || true)"
+
+          echo "  deploy-runners.yml ARC_CHART_VERSION: ${DEPLOY_VER:-<unset>}"
+          echo "  verify-runner-resources.sh CHART_VERSION: ${TEST_VER:-<unset>}"
+
+          if [ -z "${DEPLOY_VER}" ] || [ -z "${TEST_VER}" ]; then
+            echo "❌ Could not read one or both ARC chart pins."
+            exit 1
+          fi
+
+          if [ "${DEPLOY_VER}" != "${TEST_VER}" ]; then
+            echo "❌ ARC chart version pins disagree."
+            echo "   Update both so the verifier tests the deployed chart."
+            exit 1
+          fi
+          echo "✅ ARC chart pins agree (${DEPLOY_VER})"
+
       - name: Check runner pod label selectors
         run: |
           echo "🔍 Checking for stale ARC pod label selectors..."

--- a/deploy/dind-values.yaml
+++ b/deploy/dind-values.yaml
@@ -38,7 +38,7 @@ runnerScaleSetName: "redducklabs-runners"
 #
 #   helm template redducklabs-runners \
 #     oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
-#     --version 0.12.1 --kube-version 1.33.12 -f deploy/dind-values.yaml
+#     --version 0.14.2 --kube-version 1.33.12 -f deploy/dind-values.yaml
 #
 # Anything we now own that the chart used to own:
 #   - init-dind-externals init container

--- a/test/verify-runner-resources.sh
+++ b/test/verify-runner-resources.sh
@@ -23,7 +23,7 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 
 CHART="oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set"
-CHART_VERSION="${CHART_VERSION:-0.12.1}"
+CHART_VERSION="${CHART_VERSION:-0.14.2}"
 KUBE_VERSION="${KUBE_VERSION:-1.33.12}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
Second of the version-refresh workstream. Bumps ARC 0.12.1 → 0.14.2 and fixes
two defects that would have made the bump ineffective or unsafe.

## The chart bump itself is verified safe

The handoff flagged the hand-rolled dind sidecar as the main risk. Checked
before changing anything:

- The chart's **built-in dind pod spec is byte-identical** between 0.12.1 and
  0.14.2 (only chart labels and the values hash differ) → none of the sidecar
  pieces this repo owns need porting
- `deploy/dind-values.yaml` **renders identically** under both chart versions
- 0.14.2 still filters a user-supplied container named `dind`, and its
  `dind-container` template still has no `resources` field → the hand-rolled
  sidecar remains necessary, going back to `containerMode: dind` is still not
  an option
- `verify-runner-resources.sh` passes with the new default
- No breaking changes for us in the 0.13.0 → 0.14.2 release notes

## Defect 1: the controller version pin was dead code

The controller step was `helm install` guarded by
`if: controller_exists == 'false'` — it **only ran when ARC was absent**. On any
cluster that already had ARC, bumping the pinned version changed nothing.

Confirmed against the live cluster:

```
arc  arc-systems  gha-runner-scale-set-controller-0.12.1  APP 0.12.1
ghcr.io/actions/gha-runner-scale-set-controller:0.12.1
```

Merging a scale-set-only bump would have produced **controller 0.12.1 + scale
set 0.14.2**, which ARC does not support. Replaced with `helm upgrade --install`
— idempotent, expresses the desired end state, so the pin is real. Both charts
now read one `ARC_CHART_VERSION` env pin since they ship as a matched pair.

## Defect 2: Helm never upgrades CRDs

Helm applies a chart's `crds/` directory only on first install, never on
upgrade. The live cluster shows the accumulated drift:

```
controller-gen.kubebuilder.io/version: v0.14.0
```

That is **older than chart 0.12.1's own CRDs** (v0.17.2) — they have survived
untouched across multiple chart upgrades. 0.14.2 regenerates them with
controller-gen v0.20.1.

Added a **Sync ARC CRDs** step that pulls the pinned controller chart and
applies its `crds/` with **server-side apply**. Server-side is required, not
stylistic: these CRDs are **575 KB – 1.2 MB** each (they embed a full PodSpec),
and client-side apply stores the manifest in the
`last-applied-configuration` annotation, which is capped at **256 KB** — a plain
`kubectl apply` would fail outright.

All four CRDs stay on `v1alpha1` (served + storage), so there is **no
stored-version migration**.

## Drift guard

`validate-config.yml` now fails if `ARC_CHART_VERSION` and the verifier's
`CHART_VERSION` disagree — otherwise the verifier can prove invariants against a
chart the fleet does not run. Tested both directions locally (agreeing pins
pass; a simulated 0.13.0 drift is caught).

## Verification

- `helm template` diff of built-in dind, 0.12.1 vs 0.14.2 → identical
- `helm template` diff of our values, 0.12.1 vs 0.14.2 → identical
- `./test/verify-runner-resources.sh` with new defaults → all checks pass
- `actionlint` clean on both changed workflows
- YAML parses
- Live cluster state inspected read-only to confirm both defects

## Not deployed by merging

Merging does not touch the cluster. Applying this needs a manual **Deploy
GitHub Runners** run, which rolls the fleet.