### PR TITLE
chore: refresh image build toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Deploy secure, scalable GitHub Actions self-hosted runners on Kubernetes with co
 
 - **GitHub-first deployment**: Deploy, scale, monitor, and emergency-stop runners from GitHub Actions.
 - **Complete Development Environment**: Python 3.13, Node.js 22, uv, AWS CLI v2, Terraform, kubectl, Helm, and more
-- **Security Tools**: kubeconform 0.7.0, kubesec 2.14.2, Trivy 0.70.0
+- **Security Tools**: kubeconform 0.8.0, kubesec 2.14.2, Trivy 0.74.0
 - **Docker-in-Docker Support**: Build containers within runners, with a dedicated memory reservation for the Docker daemon
 - **Auto-scaling**: Configurable min/max runner instances (2 warm / 8 maximum by default)
 - **Production Ready**: Resource limits, health checks, and monitoring
@@ -92,7 +92,7 @@ docker push registry.digitalocean.com/redducklabs/github-runner:latest
 - Python 3.13.13 with pip, black, flake8, mypy, ruff, pytest, pytest-mock
 - Node.js 22.22.3 with npm, pnpm 11.5.0 (via corepack)
 - uv 0.11.17 (Python package/installer manager)
-- Go 1.26.3 runtime (for CI workflows that build Go)
+- Go 1.27.0 runtime (for CI workflows that build Go)
 - Git, curl, wget, jq, zip, unzip, bc, libmagic1
 - WeasyPrint native libs (libpango, libpangoft2, libharfbuzz, libfontconfig,
   libcairo2, libffi8) so consumer CI jobs that `import weasyprint` (PDF
@@ -111,22 +111,22 @@ docker push registry.digitalocean.com/redducklabs/github-runner:latest
 - Helm 3.21.0
 - doctl 1.160.1 (DigitalOcean CLI)
 - AWS CLI v2 2.34.57 (GPG-verified, pinned signing key)
-- Docker CLI v28.3.3+ with buildx 0.34.1 and Compose plugin (CVE-2025-54388)
+- Docker CLI v28.3.3+ with buildx 0.36.1 and Compose plugin (CVE-2025-54388)
 - GitHub CLI
 
 ### Security & Validation
-- kubeconform 0.7.0 - Kubernetes manifest validation
+- kubeconform 0.8.0 - Kubernetes manifest validation
 - kubesec 2.14.2 - Security risk analysis
-- Trivy 0.70.0 - Vulnerability scanner
-- Docker buildx 0.34.1
+- Trivy 0.74.0 - Vulnerability scanner
+- Docker buildx 0.36.1
 
 **Tool installation strategy**: kubectl, doctl, Trivy, and buildx are official
 upstream **release binaries** verified against a pinned SHA256 before install
 (this fixes the bogus `v0.0.0` / `0.0.0-dev` version strings the old source
-builds produced). kubeconform and kubesec are **source-built** with Go 1.26.3 in
+builds produced). kubeconform and kubesec are **source-built** with Go 1.27.0 in
 a throwaway builder stage because their upstream release binaries are built below
 this image's CVE floor (and both are already at their latest release); kubesec's
-`golang.org/x/crypto` is bumped (measured v0.52.0). Helm and Node install from
+`golang.org/x/crypto` is bumped (measured v0.55.0). Helm and Node install from
 official release tarballs with pinned checksums (no `curl | bash`). AWS CLI v2 is
 GPG-verified against a committed, fingerprint-pinned signing key. A clean Go
 runtime stays for CI use.
@@ -135,9 +135,9 @@ runtime stays for CI use.
 `test/verify-cve-floor.sh`**)**: every Go tool's toolchain ≥ Go 1.24.6
 (CVE-2025-47907), Trivy's `hashicorp/go-getter` ≥ v1.7.9 (CVE-2025-8959), and
 kubesec's `golang.org/x/crypto` ≥ v0.35.0 (CVE-2025-22869 / CVE-2024-45337).
-Measured at adoption: kubectl go1.26.2, doctl go1.25.0, kubeconform go1.26.3,
-kubesec go1.26.3 (x/crypto v0.52.0), trivy go1.25.9 (go-getter v1.8.6), buildx
-go1.26.3. Trivy's full HIGH/CRITICAL scan runs **report-only** (SARIF to the
+Measured at adoption: kubectl go1.26.2, doctl go1.25.0, kubeconform go1.27.0,
+kubesec go1.27.0 (x/crypto v0.55.0), trivy go1.26.6 (go-getter v1.8.6), buildx
+go1.26.5. Trivy's full HIGH/CRITICAL scan runs **report-only** (SARIF to the
 Security tab) because upstream release binaries and the dind base image carry
 fixed CVEs we cannot remediate; the deterministic CVE-floor gate is the enforcing
 check.
@@ -160,16 +160,16 @@ These are the current pins in `docker/Dockerfile.custom-runner`.
 | Node.js | 22.22.3 | nodejs.org tarball + SHA256 |
 | pnpm | 11.5.0 | corepack |
 | uv | 0.11.17 | release tarball + SHA256 |
-| Go (runtime) | 1.26.3 | go.dev tarball + SHA256 |
+| Go (runtime) | 1.27.0 | go.dev tarball + SHA256 |
 | Terraform | 1.15.5 | HashiCorp apt, keyring fingerprint + exact pin |
 | kubectl | 1.36.1 | release binary + SHA256 |
 | Helm | 3.21.0 | get.helm.sh tarball + SHA256 |
 | doctl | 1.160.1 | release binary + SHA256 |
 | AWS CLI | v2 2.34.57 | bundle + GPG (pinned key) |
-| kubeconform | 0.7.0 | source-built (Go 1.26.3) |
-| kubesec | 2.14.2 | source-built (Go 1.26.3, x/crypto v0.52.0) |
-| Trivy | 0.70.0 | release tarball + SHA256 |
-| buildx | 0.34.1 | release binary + SHA256 |
+| kubeconform | 0.8.0 | source-built (Go 1.27.0) |
+| kubesec | 2.14.2 | source-built (Go 1.27.0, x/crypto v0.55.0) |
+| Trivy | 0.74.0 | release tarball + SHA256 |
+| buildx | 0.36.1 | release binary + SHA256 |
 | Docker CLI / Compose | floating (>= 28.3.3 enforced) | Docker apt, keyring fingerprint |
 | GitHub CLI | floating | GitHub apt, keyring fingerprint |
 
@@ -346,8 +346,8 @@ the live runner fleet, so use them only when local operations are intended.
 
 **CVE-2025-47907 (HIGH)** - Go stdlib vulnerability (database/sql, Postgres):
 - Enforced via the CVE-floor gate: every Go tool's toolchain must be ≥ Go 1.24.6.
-- Measured: kubectl go1.26.2, doctl go1.25.0, kubeconform go1.26.3, kubesec
-  go1.26.3, trivy go1.25.9, buildx go1.26.3 — all above the floor.
+- Measured: kubectl go1.26.2, doctl go1.25.0, kubeconform go1.27.0, kubesec
+  go1.27.0, trivy go1.26.6, buildx go1.26.5 — all above the floor.
 
 **CVE-2025-55199 & CVE-2025-55198 (MEDIUM)** - Fixed Helm vulnerabilities:
 - **CVE-2025-55199**: Helm Chart JSON Schema Denial of Service vulnerability
@@ -355,11 +355,11 @@ the live runner fleet, so use them only when local operations are intended.
 - **Helm**: Updated to v3.21.0 (tarball + pinned SHA256).
 
 **CVE-2025-8959** - go-getter vulnerability in Trivy:
-- **Fix**: Trivy 0.70.0's release binary embeds `hashicorp/go-getter` v1.8.6
+- **Fix**: Trivy 0.74.0's release binary embeds `hashicorp/go-getter` v1.8.6
   (≥ v1.7.9). Verified by the CVE-floor gate; no source build needed.
 
 **CVE-2025-22869 / CVE-2024-45337** - golang.org/x/crypto (SSH) in kubesec:
-- **Fix**: kubesec is source-built with `x/crypto` bumped to v0.52.0
+- **Fix**: kubesec is source-built with `x/crypto` bumped to v0.55.0
   (≥ v0.35.0). Verified by the CVE-floor gate.
 
 The CVE-floor gate (`test/verify-cve-floor.sh`) enforces these specific CVE
@@ -432,7 +432,7 @@ The runner image uses a comprehensive multi-stage build process to eliminate sec
   time and in CI (`test/verify-cve-floor.sh`).
 
 **Build Stages:**
-1. **Go Builder Stage**: source-builds kubeconform and kubesec with Go 1.26.3
+1. **Go Builder Stage**: source-builds kubeconform and kubesec with Go 1.27.0
    (their upstream release binaries are below the CVE floor).
 2. **Python Builder Stage**: Installs Python development tools in isolation.
 3. **Final Runtime Stage**: installs release binaries (kubectl, doctl, Trivy,

--- a/docker/Dockerfile.custom-runner
+++ b/docker/Dockerfile.custom-runner
@@ -3,10 +3,10 @@
 # official release binaries; kubeconform and kubesec are source-built because their
 # release binaries are below the CVE floor. See
 # docs/specs/2026-05-31-runner-toolchain-refresh-design.md.
-ARG GO_VERSION=1.26.3
-ARG GO_SHA256=2b2cfc7148493da5e73981bffbf3353af381d5f93e789c82c79aff64962eb556
-ARG TRIVY_VERSION=v0.70.0
-ARG TRIVY_SHA256=8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9
+ARG GO_VERSION=1.27.0
+ARG GO_SHA256=675c26c449cbb18fc24b74650de1eabbae6e16f64326fd85a283fb3b58280685
+ARG TRIVY_VERSION=v0.74.0
+ARG TRIVY_SHA256=2ae6fe3ee734b7fdf11335663e18c75ea12dccc76062f09f164a3b0f8be4371a
 ARG KUBECTL_VERSION=v1.36.1
 ARG KUBECTL_SHA256=629d3f410e09bf49b64ae7079f7f0bda1191efed311f7d37fdbab0ad5b0ec2b7
 # doctl v1.160.0 was withdrawn upstream (the release/asset now 404s, breaking
@@ -17,16 +17,16 @@ ARG DOCTL_SHA256=615b03e678ffe391b3f3a3afe74a125f7fde1842135b7c3528862eba9ff1616
 # kubeconform and kubesec are built from source in the go-builder stage (their
 # upstream release binaries are below the CVE floor), so only the version pins
 # are needed here -- no download checksum.
-ARG KUBECONFORM_VERSION=v0.7.0
+ARG KUBECONFORM_VERSION=v0.8.0
 ARG KUBESEC_VERSION=v2.14.2
 # Pinned x/crypto for the kubesec source build (CVE-2025-22869 / CVE-2024-45337).
 # Keep deterministic; the CVE-floor gate enforces >= v0.35.0.
-ARG KUBESEC_XCRYPTO_VERSION=v0.52.0
+ARG KUBESEC_XCRYPTO_VERSION=v0.55.0
 ARG HELM_VERSION=v3.21.0
 ARG HELM_SHA256=0093eb572e3d2380f094df162ddb525e219249de88957afe24cfbb19632acd36
 ARG TERRAFORM_VERSION=1.15.5-1
-ARG BUILDX_VERSION=v0.34.1
-ARG BUILDX_SHA256=f1332ddb9010bd0b72628266c3a906d9a6979848033df4c8d9bd2cd113bae12b
+ARG BUILDX_VERSION=v0.36.1
+ARG BUILDX_SHA256=48af8a397ebd60178778bf63611dbcebe5f5e7a9be90eb9147b24b9587455778
 ARG UV_VERSION=0.11.17
 ARG UV_SHA256=0017ccecaeb4d431d7f93b583ebff0c5c38e00eb734fcf13d05f72ca419125fe
 ARG AWSCLI_VERSION=2.34.57

--- a/docs/toolchain/dockerfile-security-refactor.md
+++ b/docs/toolchain/dockerfile-security-refactor.md
@@ -10,11 +10,11 @@
   plus Node.js, Helm, and uv install from official upstream release artifacts
   verified against a pinned SHA256 before install. This fixed the bogus
   `v0.0.0` / `0.0.0-dev` version strings the old source builds produced.
-- **Source-built (Go 1.26.3) in a minimal `go-builder` stage:** `kubeconform`
+- **Source-built (Go 1.27.0) in a minimal `go-builder` stage:** `kubeconform`
   and `kubesec` only. Their upstream release binaries are built below this
   image's CVE floor (kubeconform Go 1.24.2; kubesec Go 1.23.1 + x/crypto
   v0.29.0), and both are at their latest release, so they are compiled with Go
-  1.26.3 and kubesec's `golang.org/x/crypto` is bumped to v0.52.0. The builder's
+  1.27.0 and kubesec's `golang.org/x/crypto` is bumped to v0.55.0. The builder's
   module cache lives only in the throwaway stage and never reaches the final
   image.
 - **AWS CLI v2:** GPG-verified against a committed, fingerprint-pinned signing
@@ -25,9 +25,13 @@
   and in CI — every Go tool toolchain ≥ Go 1.24.6, Trivy go-getter ≥ v1.7.9,
   kubesec x/crypto ≥ v0.35.0. Trivy's full HIGH/CRITICAL scan is **report-only**
   (upstream-binary and dind base-image fixed CVEs cannot be remediated here).
-- **Go runtime:** a clean Go 1.26.3 stays in the final image for CI workflows.
+- **Go runtime:** a clean Go 1.27.0 stays in the final image for CI workflows.
 
-Measured toolchains at adoption (2026-06-01): kubectl go1.26.2, doctl go1.25.0,
+Measured toolchains (2026-08-19 version refresh): kubectl go1.26.2, doctl
+go1.25.0, kubeconform go1.27.0, kubesec go1.27.0 (x/crypto v0.55.0), trivy
+go1.26.6 (go-getter v1.8.6), buildx go1.26.5.
+
+Previously measured at adoption (2026-06-01): kubectl go1.26.2, doctl go1.25.0,
 kubeconform go1.26.3, kubesec go1.26.3 (x/crypto v0.52.0), trivy go1.25.9
 (go-getter v1.8.6), buildx go1.26.3.
 

--- a/docs/toolchain/go-runtime.md
+++ b/docs/toolchain/go-runtime.md
@@ -1,6 +1,6 @@
 # Go Runtime Fix - Critical Functionality Restoration
 
-> **Update (2026 toolchain refresh):** the clean Go runtime is now **Go 1.26.3**
+> **Update (2026 toolchain refresh):** the clean Go runtime is now **Go 1.27.0**
 > (was 1.24.6). The broad five-tool Go source-build stage was replaced by release
 > binaries for kubectl/doctl/trivy/buildx; a **minimal** `go-builder` stage
 > remains only to source-build kubeconform and kubesec (their release binaries

--- a/test/verify-tools.sh
+++ b/test/verify-tools.sh
@@ -91,9 +91,9 @@ print('✓ Chromium runtime libraries loadable')
 echo ""
 
 # Test security tools
-test_tool "kubeconform 0.7.0" "kubeconform -v"
+test_tool "kubeconform 0.8.0" "kubeconform -v"
 test_tool "kubesec 2.14.2" "kubesec version"
-test_tool "Trivy 0.70.0" "trivy version | grep Version"
+test_tool "Trivy 0.74.0" "trivy version | grep Version"
 
 echo "====================================================="
 echo -e "${GREEN}All tools verified successfully in redducklabs runners!${NC}"


### PR DESCRIPTION
Third of the version-refresh workstream, part A. **Build-internal** toolchain
bumps: these affect how the image is built and what the security gates measure,
not the CLIs consumer workflows invoke. The consumer-facing tools (kubectl,
Helm, doctl, Terraform, Node, Python, uv, AWS CLI) move in a separate PR so a
broken consumer build has an unambiguous cause.

| Tool | Before | After |
|---|---|---|
| Go | 1.26.3 | 1.27.0 |
| Trivy | v0.70.0 | v0.74.0 |
| kubeconform (source-built) | v0.7.0 | v0.8.0 |
| buildx | v0.34.1 | v0.36.1 |
| kubesec `x/crypto` (source-built) | v0.52.0 | v0.55.0 |

kubesec itself stays at **v2.14.2** — already the latest release.

## Verified, not assumed

**Built the `go-builder` stage locally with Docker.** It reports:

```
kubeconform go1.27.0
kubesec go1.27.0
kubesec x/crypto v0.55.0
```

and both binaries execute (`kubesec version` → `v2.14.2`).

**Downloaded the release artifacts and confirmed they hash to the pinned
SHA256s** — trivy, buildx (and kubectl, doctl for the follow-up PR) all match
exactly.

**Measured the new binaries against the CVE floor** using the Go toolchain from
the builder stage:

| Binary | Toolchain | Floor Go 1.24.6 |
|---|---|---|
| trivy 0.74.0 | go1.26.6-X:jsonv2 | ✅ |
| buildx 0.36.1 | go1.26.5 | ✅ |

Trivy's `hashicorp/go-getter` is **v1.8.6** (floor v1.7.9) ✅, and kubesec's
`x/crypto` is **v0.55.0** (floor v0.35.0) ✅.

## One thing worth flagging

Trivy 0.74.0's toolchain string is now `go1.26.6-X:jsonv2` — a GOEXPERIMENT
suffix it did not previously carry. I checked that `verify-cve-floor.sh`'s
version parser handles it: `ge_floor` short-circuits on the minor comparison
(26 > 24) and returns before the malformed patch component `6-X:jsonv2` is ever
evaluated by `-ge`. Confirmed by running the parser against the real strings.
It is safe now; it would only misbehave if a suffixed toolchain ever landed on
the floor's exact minor.

## Docs

README, `docs/toolchain/go-runtime.md`, and
`docs/toolchain/dockerfile-security-refactor.md` updated with the **measured**
figures. The historical "at adoption (2026-06-01)" measurements are preserved
alongside the new ones rather than overwritten. `test/verify-tools.sh` version
labels updated for kubeconform and Trivy.

CVE floor, source-build policy, and checksum verification are all unchanged —
every version moves upward.