### PR TITLE
chore: refresh runner toolchain versions

### DIFF
--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -129,8 +129,33 @@ jobs:
             bc --version | head -1
             python3 -c "import pytest_mock"
             echo ALL_TOOLS_OK'
-          docker run --rm "$IMG" doctl version | grep -q 1.160
-          docker run --rm "$IMG" kubectl version --client -o json | grep -q '"gitVersion": "v1.36'
+          # Assert the image ships the versions the Dockerfile pins. Read the
+          # expected values out of the Dockerfile rather than hardcoding them:
+          # these assertions used to be `grep -q 1.160` and
+          # `grep -q '"gitVersion": "v1.36'`, which rot on every bump. Because
+          # `grep -q` is silent, a stale assertion fails the job with NO output
+          # at all, which is needlessly hard to diagnose - so each check below
+          # prints what it got before failing.
+          DF=docker/Dockerfile.custom-runner
+          KUBECTL_EXPECT=$(grep -oP '^ARG KUBECTL_VERSION=\K.*' "$DF")
+          DOCTL_EXPECT=$(grep -oP '^ARG DOCTL_VERSION=\K.*' "$DF")
+          [ -n "$KUBECTL_EXPECT" ] && [ -n "$DOCTL_EXPECT" ] || {
+            echo "FAIL: could not read version pins from $DF"; exit 1; }
+
+          DOCTL_GOT=$(docker run --rm "$IMG" doctl version | head -1)
+          echo "doctl: $DOCTL_GOT (expect ${DOCTL_EXPECT#v})"
+          case "$DOCTL_GOT" in
+            *"${DOCTL_EXPECT#v}"*) echo "OK doctl version" ;;
+            *) echo "FAIL: doctl reports '$DOCTL_GOT', expected ${DOCTL_EXPECT#v}"; exit 1 ;;
+          esac
+
+          KUBECTL_GOT=$(docker run --rm "$IMG" kubectl version --client -o json | grep gitVersion)
+          echo "kubectl: $KUBECTL_GOT (expect $KUBECTL_EXPECT)"
+          case "$KUBECTL_GOT" in
+            *"\"$KUBECTL_EXPECT\""*) echo "OK kubectl version" ;;
+            *) echo "FAIL: kubectl reports '$KUBECTL_GOT', expected $KUBECTL_EXPECT"; exit 1 ;;
+          esac
+
           docker run --rm "$IMG" kubesec version | grep -vq '0.0.0'
           # WeasyPrint's hard (import-time) native libs must load via ctypes —
           # consumer CI jobs that `import weasyprint` fail at collection

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ docker push registry.digitalocean.com/redducklabs/github-runner:latest
 ## Included Tools
 
 ### Development Tools
-- Python 3.13.13 with pip, black, flake8, mypy, ruff, pytest, pytest-mock
-- Node.js 22.22.3 with npm, pnpm 11.5.0 (via corepack)
-- uv 0.11.17 (Python package/installer manager)
+- Python 3.13.15 with pip, black, flake8, mypy, ruff, pytest, pytest-mock
+- Node.js 22.23.2 with npm, pnpm 11.5.0 (via corepack)
+- uv 0.12.5 (Python package/installer manager)
 - Go 1.27.0 runtime (for CI workflows that build Go)
 - Git, curl, wget, jq, zip, unzip, bc, libmagic1
 - WeasyPrint native libs (libpango, libpangoft2, libharfbuzz, libfontconfig,
@@ -106,11 +106,11 @@ docker push registry.digitalocean.com/redducklabs/github-runner:latest
   `@playwright/test` version.
 
 ### Infrastructure Tools
-- Terraform 1.15.5
-- kubectl 1.36.1
-- Helm 3.21.0
-- doctl 1.160.1 (DigitalOcean CLI)
-- AWS CLI v2 2.34.57 (GPG-verified, pinned signing key)
+- Terraform 1.15.9
+- kubectl 1.36.3
+- Helm 3.21.4
+- doctl 1.167.0 (DigitalOcean CLI)
+- AWS CLI v2 2.36.27 (GPG-verified, pinned signing key)
 - Docker CLI v28.3.3+ with buildx 0.36.1 and Compose plugin (CVE-2025-54388)
 - GitHub CLI
 
@@ -135,7 +135,7 @@ runtime stays for CI use.
 `test/verify-cve-floor.sh`**)**: every Go tool's toolchain ≥ Go 1.24.6
 (CVE-2025-47907), Trivy's `hashicorp/go-getter` ≥ v1.7.9 (CVE-2025-8959), and
 kubesec's `golang.org/x/crypto` ≥ v0.35.0 (CVE-2025-22869 / CVE-2024-45337).
-Measured at adoption: kubectl go1.26.2, doctl go1.25.0, kubeconform go1.27.0,
+Measured at adoption: kubectl go1.26.5, doctl go1.25.0, kubeconform go1.27.0,
 kubesec go1.27.0 (x/crypto v0.55.0), trivy go1.26.6 (go-getter v1.8.6), buildx
 go1.26.5. Trivy's full HIGH/CRITICAL scan runs **report-only** (SARIF to the
 Security tab) because upstream release binaries and the dind base image carry
@@ -156,16 +156,16 @@ These are the current pins in `docker/Dockerfile.custom-runner`.
 | Tool | Version | Source / pin |
 |------|---------|--------------|
 | GitHub Actions Runner | 2.336.0 | official GitHub runner base image |
-| Python | 3.13.13 (python-build-standalone rel 20260510) | tarball + SHA256 |
-| Node.js | 22.22.3 | nodejs.org tarball + SHA256 |
+| Python | 3.13.15 (python-build-standalone rel 20260814) | tarball + SHA256 |
+| Node.js | 22.23.2 | nodejs.org tarball + SHA256 |
 | pnpm | 11.5.0 | corepack |
-| uv | 0.11.17 | release tarball + SHA256 |
+| uv | 0.12.5 | release tarball + SHA256 |
 | Go (runtime) | 1.27.0 | go.dev tarball + SHA256 |
-| Terraform | 1.15.5 | HashiCorp apt, keyring fingerprint + exact pin |
-| kubectl | 1.36.1 | release binary + SHA256 |
-| Helm | 3.21.0 | get.helm.sh tarball + SHA256 |
-| doctl | 1.160.1 | release binary + SHA256 |
-| AWS CLI | v2 2.34.57 | bundle + GPG (pinned key) |
+| Terraform | 1.15.9 | HashiCorp apt, keyring fingerprint + exact pin |
+| kubectl | 1.36.3 | release binary + SHA256 |
+| Helm | 3.21.4 | get.helm.sh tarball + SHA256 |
+| doctl | 1.167.0 | release binary + SHA256 |
+| AWS CLI | v2 2.36.27 | bundle + GPG (pinned key) |
 | kubeconform | 0.8.0 | source-built (Go 1.27.0) |
 | kubesec | 2.14.2 | source-built (Go 1.27.0, x/crypto v0.55.0) |
 | Trivy | 0.74.0 | release tarball + SHA256 |
@@ -346,13 +346,13 @@ the live runner fleet, so use them only when local operations are intended.
 
 **CVE-2025-47907 (HIGH)** - Go stdlib vulnerability (database/sql, Postgres):
 - Enforced via the CVE-floor gate: every Go tool's toolchain must be ≥ Go 1.24.6.
-- Measured: kubectl go1.26.2, doctl go1.25.0, kubeconform go1.27.0, kubesec
+- Measured: kubectl go1.26.5, doctl go1.25.0, kubeconform go1.27.0, kubesec
   go1.27.0, trivy go1.26.6, buildx go1.26.5 — all above the floor.
 
 **CVE-2025-55199 & CVE-2025-55198 (MEDIUM)** - Fixed Helm vulnerabilities:
 - **CVE-2025-55199**: Helm Chart JSON Schema Denial of Service vulnerability
 - **CVE-2025-55198**: Helm YAML Parsing Panic vulnerability
-- **Helm**: Updated to v3.21.0 (tarball + pinned SHA256).
+- **Helm**: Updated to v3.21.4 (tarball + pinned SHA256).
 
 **CVE-2025-8959** - go-getter vulnerability in Trivy:
 - **Fix**: Trivy 0.74.0's release binary embeds `hashicorp/go-getter` v1.8.6

--- a/docker/Dockerfile.custom-runner
+++ b/docker/Dockerfile.custom-runner
@@ -255,9 +255,16 @@ RUN set -eux && \
     tar -xzf doctl.tgz && install -m 0755 doctl /usr/local/bin/doctl && \
     # cleanup
     rm -f /tmp/kubectl /tmp/doctl /tmp/doctl.tgz && \
-    # verify meaningful (non-0.0.0) versions
-    kubectl version --client -o json | grep -q '"gitVersion": "v1.36' && \
-    doctl version | grep -q '1.160'
+    # Verify each binary reports the version we pinned. Derived from the ARGs on
+    # purpose: these assertions used to hardcode the version prefix
+    # ('"gitVersion": "v1.36' and '1.160'), which silently rots on every bump -
+    # the doctl one broke this build the moment DOCTL_VERSION moved past 1.160,
+    # and the kubectl one only survived because 1.36.1 -> 1.36.3 happened to stay
+    # inside the hardcoded prefix. Deriving from the ARG keeps the original
+    # intent (catch bogus 0.0.0/dev version strings) and additionally catches
+    # installing a different version than the one pinned.
+    kubectl version --client -o json | grep -q "gitVersion.*${KUBECTL_VERSION}" && \
+    doctl version | grep -q "${DOCTL_VERSION#v}"
 
 # Copy source-built kubeconform and kubesec from the go-builder stage.
 COPY --from=go-builder /tmp/binaries/kubeconform /tmp/binaries/kubesec /usr/local/bin/

--- a/docker/Dockerfile.custom-runner
+++ b/docker/Dockerfile.custom-runner
@@ -7,13 +7,14 @@ ARG GO_VERSION=1.27.0
 ARG GO_SHA256=675c26c449cbb18fc24b74650de1eabbae6e16f64326fd85a283fb3b58280685
 ARG TRIVY_VERSION=v0.74.0
 ARG TRIVY_SHA256=2ae6fe3ee734b7fdf11335663e18c75ea12dccc76062f09f164a3b0f8be4371a
-ARG KUBECTL_VERSION=v1.36.1
-ARG KUBECTL_SHA256=629d3f410e09bf49b64ae7079f7f0bda1191efed311f7d37fdbab0ad5b0ec2b7
-# doctl v1.160.0 was withdrawn upstream (the release/asset now 404s, breaking
-# the build); v1.160.1 is the current stable patch. SHA256 from DigitalOcean's
-# published doctl-1.160.1-checksums.sha256.
-ARG DOCTL_VERSION=v1.160.1
-ARG DOCTL_SHA256=615b03e678ffe391b3f3a3afe74a125f7fde1842135b7c3528862eba9ff16168
+ARG KUBECTL_VERSION=v1.36.3
+ARG KUBECTL_SHA256=ebbd080e7c2e275093b55915722043257eb24004363e20acb3c4d71919f88336
+# SHA256 from DigitalOcean's published doctl-<version>-checksums.sha256.
+# Note when bumping: DigitalOcean has withdrawn a doctl release before (v1.160.0
+# was pulled and its assets began 404ing, breaking the build), so confirm the
+# release assets actually resolve rather than trusting the tag list.
+ARG DOCTL_VERSION=v1.167.0
+ARG DOCTL_SHA256=8d7b39ad749698693458aa701c0c8d522035f923455a9bf0ee03a0b01601e51c
 # kubeconform and kubesec are built from source in the go-builder stage (their
 # upstream release binaries are below the CVE floor), so only the version pins
 # are needed here -- no download checksum.
@@ -22,23 +23,23 @@ ARG KUBESEC_VERSION=v2.14.2
 # Pinned x/crypto for the kubesec source build (CVE-2025-22869 / CVE-2024-45337).
 # Keep deterministic; the CVE-floor gate enforces >= v0.35.0.
 ARG KUBESEC_XCRYPTO_VERSION=v0.55.0
-ARG HELM_VERSION=v3.21.0
-ARG HELM_SHA256=0093eb572e3d2380f094df162ddb525e219249de88957afe24cfbb19632acd36
-ARG TERRAFORM_VERSION=1.15.5-1
+ARG HELM_VERSION=v3.21.4
+ARG HELM_SHA256=61f88ab166748cb19604d7884cb100ae9ccb13804ddeb98e08af167eacbb6a14
+ARG TERRAFORM_VERSION=1.15.9-1
 ARG BUILDX_VERSION=v0.36.1
 ARG BUILDX_SHA256=48af8a397ebd60178778bf63611dbcebe5f5e7a9be90eb9147b24b9587455778
-ARG UV_VERSION=0.11.17
-ARG UV_SHA256=0017ccecaeb4d431d7f93b583ebff0c5c38e00eb734fcf13d05f72ca419125fe
-ARG AWSCLI_VERSION=2.34.57
+ARG UV_VERSION=0.12.5
+ARG UV_SHA256=68a509da24b06b4223a1c0175fb5eb5bc79342b76cbeff0cfe51ac3f5b17b6b2
+ARG AWSCLI_VERSION=2.36.27
 ARG PYTHON_VERSION=3.13
-ARG PYTHON_BUILD_RELEASE=20260510
-ARG PYTHON_FULL_VERSION=3.13.13
-ARG PYTHON_TARBALL_SHA256=928d08ecda5bbf4d8851c5872e363dd9c9be938fdb90f525b6f36a8c90ff8407
+ARG PYTHON_BUILD_RELEASE=20260814
+ARG PYTHON_FULL_VERSION=3.13.15
+ARG PYTHON_TARBALL_SHA256=45816a2653b47a6cc48d8ada4ea1185758a4c2db389d012b31e0205e5ccb548b
 # Node installs from the official nodejs.org release tarball (verified SHA256),
 # not NodeSource apt: NodeSource's node_22.x deb channel is stale at 22.15.0 and
-# cannot deliver 22.22.3 (the current Node 22 LTS).
-ARG NODE_VERSION=22.22.3
-ARG NODE_SHA256=c7a10d6816da8eaaa7534dd73c71c6e2b2c391dbbf845e364902d156615dd1b8
+# cannot deliver 22.23.2 (the current Node 22 LTS).
+ARG NODE_VERSION=22.23.2
+ARG NODE_SHA256=b294a556e639d64338823920e5866c21c02741742d2e1529ee1a225c1ec9252a
 ARG ACTIONS_RUNNER_BASE=ghcr.io/actions/actions-runner:2.336.0
 # Playwright minor used only to resolve Chromium's apt system-dep list at build
 # (install-deps). The consumer downloads its own browser binary at job time, so
@@ -211,7 +212,7 @@ COPY --from=python-builder /tmp/python-packages /opt/python/lib/python${PYTHON_V
 
 # Install Node.js from the official nodejs.org release tarball (verified SHA256).
 # NodeSource's node_22.x apt channel is stale at 22.15.0 and cannot deliver the
-# current 22.22.3 LTS, so we pin and checksum the upstream binary instead, in
+# current 22.23.2 LTS, so we pin and checksum the upstream binary instead, in
 # line with the other release-binary tools in this image. pnpm via corepack
 # (bundled with Node); we never `npm install -g`.
 RUN set -eux && \

--- a/docs/toolchain/dockerfile-security-refactor.md
+++ b/docs/toolchain/dockerfile-security-refactor.md
@@ -27,7 +27,7 @@
   (upstream-binary and dind base-image fixed CVEs cannot be remediated here).
 - **Go runtime:** a clean Go 1.27.0 stays in the final image for CI workflows.
 
-Measured toolchains (2026-08-19 version refresh): kubectl go1.26.2, doctl
+Measured toolchains (2026-08-19 version refresh): kubectl go1.26.5, doctl
 go1.25.0, kubeconform go1.27.0, kubesec go1.27.0 (x/crypto v0.55.0), trivy
 go1.26.6 (go-getter v1.8.6), buildx go1.26.5.
 

--- a/test/verify-tools.sh
+++ b/test/verify-tools.sh
@@ -39,15 +39,15 @@ test_tool() {
 }
 
 # Test each tool
-test_tool "Python 3.13.13" "python3 --version"
-test_tool "Node.js 22.22.3" "node --version"
+test_tool "Python 3.13.15" "python3 --version"
+test_tool "Node.js 22.23.2" "node --version"
 test_tool "npm" "npm --version"
 test_tool "pnpm" "pnpm --version"
 test_tool "uv" "uv --version"
-test_tool "Terraform 1.15.5" "terraform version -json | jq -r .terraform_version"
-test_tool "kubectl 1.36.1" "kubectl version --client -o json | jq -r .clientVersion.gitVersion"
-test_tool "Helm 3.21.0" "helm version --short"
-test_tool "doctl 1.160.1" "doctl version"
+test_tool "Terraform 1.15.9" "terraform version -json | jq -r .terraform_version"
+test_tool "kubectl 1.36.3" "kubectl version --client -o json | jq -r .clientVersion.gitVersion"
+test_tool "Helm 3.21.4" "helm version --short"
+test_tool "doctl 1.167.0" "doctl version"
 test_tool "AWS CLI" "aws --version"
 test_tool "Docker CLI" "docker --version"
 test_tool "Docker Compose" "docker compose version"


### PR DESCRIPTION
Third of the version-refresh workstream, part B. **Consumer-facing** CLI and
runtime bumps — the tools consumer workflows actually invoke. Split from the
build-internal refresh (#27) so a broken consumer build has an unambiguous
cause.

| Tool | Before | After |
|---|---|---|
| kubectl | v1.36.1 | v1.36.3 |
| Helm | v3.21.0 | v3.21.4 |
| doctl | v1.160.1 | v1.167.0 |
| Terraform | 1.15.5-1 | 1.15.9-1 |
| uv | 0.11.17 | 0.12.5 |
| AWS CLI | 2.34.57 | 2.36.27 |
| Node.js | 22.22.3 | 22.23.2 |
| Python | 3.13.13 | 3.13.15 (pbs rel 20260814) |

## Deliberately not bumped

- **Helm stays on 3.x.** Helm 4.2.4 is released. A Helm major is a
  consumer-visible change and is not being smuggled into a patch sweep.
- **Node stays on 22 (Jod).** 24 (Krypton) is the current active LTS, but
  moving lines can break native module builds downstream. Node 22 is supported
  into 2027.
- **Python stays on 3.13.** 3.14.7 is available, but C-extension wheels can lag
  a new minor and break consumer `pip install`s.
- **Playwright stays at 1.60.0.** Per the Dockerfile's own comment it tracks the
  consumer's `@playwright/test` MINOR to resolve Chromium's apt dep list — not
  upstream latest (1.62.1).
- **actions-runner base (2.336.0)** and **`docker:29.7.2-dind`** are already at
  the current release.

## Checksums were verified, not copied

Every artifact was downloaded and hashed locally against the pin in this diff:

```
kubectl  ebbd080e…88336  ✅
helm     61f88ab1…6a14   ✅
doctl    8d7b39ad…e51c   ✅
uv       68a509da…b6b2   ✅
node     b294a556…252a   ✅
```

The Python tarball hash was additionally cross-checked against upstream's
published `SHA256SUMS` manifest for release 20260814 rather than trusting a
locally computed digest alone.

Also confirmed `terraform 1.15.9-1` is actually published for **noble** in the
HashiCorp apt repo (the Dockerfile resolves the codename via `lsb_release -cs`),
and that AWS CLI `2.36.27` resolves.

`./test/verify-aws-key-expiry.sh` passes — signing key valid until 2027-07-01.

## Housekeeping

The doctl comment about the withdrawn v1.160.0 was stale (that version is long
past). Rewritten as a forward-looking note, since the specific version no longer
applies but the failure mode — DigitalOcean pulling a release and its assets
404ing mid-build — is worth remembering on future bumps.

`test/verify-tools.sh` version labels updated to match.