### PR TITLE
fix: remove the last hardcoded version assertion and guard against new ones

### DIFF
--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -419,8 +419,29 @@ jobs:
             gh --version | head -1; psql --version; redis-cli --version
             bc --version | head -1
             python3 -c "import pytest_mock"'
-          docker run --rm "$IMG" kubectl version --client -o json | grep -q '"gitVersion": "v1.36'
-          docker run --rm "$IMG" doctl version | grep -q 1.160
+          # Same ARG-derived assertions as the PR smoke test above - see the
+          # comment there. This job runs only on main, so a stale hardcoded pin
+          # here survives every PR and fails only after the image is published.
+          DF=docker/Dockerfile.custom-runner
+          KUBECTL_EXPECT=$(grep -oP '^ARG KUBECTL_VERSION=\K.*' "$DF")
+          DOCTL_EXPECT=$(grep -oP '^ARG DOCTL_VERSION=\K.*' "$DF")
+          [ -n "$KUBECTL_EXPECT" ] && [ -n "$DOCTL_EXPECT" ] || {
+            echo "FAIL: could not read version pins from $DF"; exit 1; }
+
+          KUBECTL_GOT=$(docker run --rm "$IMG" kubectl version --client -o json | grep gitVersion)
+          echo "kubectl: $KUBECTL_GOT (expect $KUBECTL_EXPECT)"
+          case "$KUBECTL_GOT" in
+            *"\"$KUBECTL_EXPECT\""*) echo "OK kubectl version" ;;
+            *) echo "FAIL: kubectl reports '$KUBECTL_GOT', expected $KUBECTL_EXPECT"; exit 1 ;;
+          esac
+
+          DOCTL_GOT=$(docker run --rm "$IMG" doctl version | head -1)
+          echo "doctl: $DOCTL_GOT (expect ${DOCTL_EXPECT#v})"
+          case "$DOCTL_GOT" in
+            *"${DOCTL_EXPECT#v}"*) echo "OK doctl version" ;;
+            *) echo "FAIL: doctl reports '$DOCTL_GOT', expected ${DOCTL_EXPECT#v}"; exit 1 ;;
+          esac
+
           docker run --rm "$IMG" kubesec version | grep -vq '0.0.0'
           # WeasyPrint's hard (import-time) native libs (consumer CI jobs
           # import weasyprint); optional HarfBuzz subset lib omitted by design.

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -145,6 +145,31 @@ jobs:
           fi
           echo "✅ ARC chart pins agree (${DEPLOY_VER})"
 
+      - name: Check for hardcoded tool version assertions
+        run: |
+          echo "🔍 Checking for hardcoded version assertions in workflows..."
+          # Anti-pattern: asserting a tool's version with a literal, e.g.
+          #     doctl version | grep -q 1.160
+          #     kubectl version --client -o json | grep -q '"gitVersion": "v1.36'
+          # These rot on every version bump. Three copies of exactly this
+          # existed (the Dockerfile install step, the PR smoke test, and the
+          # main-only security-scan verify step); the doctl one broke the build
+          # on a bump, and the third copy failed only AFTER the image was
+          # published because that job never runs on a PR. Worse, `grep -q` is
+          # silent, so the job died with no indication of which check failed.
+          # Derive expected versions from the Dockerfile ARGs instead, and print
+          # what was found before failing.
+          if grep -rnE "version.*\|[[:space:]]*grep[[:space:]]+-q[[:space:]].*[0-9]+\.[0-9]+" \
+               --exclude=validate-config.yml .github/workflows/; then
+            echo ""
+            echo "❌ Hardcoded tool version assertion found (shown above)."
+            echo "   Read the expected value from docker/Dockerfile.custom-runner:"
+            echo "     EXPECT=\$(grep -oP '^ARG FOO_VERSION=\\K.*' \"\$DF\")"
+            echo "   and print the actual value before exiting non-zero."
+            exit 1
+          fi
+          echo "✅ No hardcoded tool version assertions"
+
       - name: Check runner pod label selectors
         run: |
           echo "🔍 Checking for stale ARC pod label selectors..."


### PR DESCRIPTION
Follow-up to #28. The push to `main` published the image successfully but the
`security-scan` job failed on a **third copy** of the hardcoded version
assertions fixed in #28:

```
docker run --rm "$IMG" kubectl version --client -o json | grep -q '"gitVersion": "v1.36'
docker run --rm "$IMG" doctl version | grep -q 1.160
```

**The published image is fine.** `Build Runner (publish)` succeeded and the CVE
floor gate passed on the built image:

```
kubectl go1.26.5 | doctl go1.25.0 | kubeconform go1.27.0
kubesec go1.27.0 | trivy go1.26.6-X:jsonv2 | buildx go1.26.5
go-getter v1.8.6 | x/crypto v0.55.0    → CVE FLOOR GATE: PASS
```

This was a stale string comparison, not a security finding.

## Why this copy was the nastiest

`security-scan` runs **only on main**. So this assertion:

- passed every PR check, including #28's
- failed only on the push to `main`
- failed **after** the image was already pushed to the registry
- surfaced as a red "security-scan" job, which reads like a vulnerability

and because `grep -q` is silent, the log showed the tool versions, then a bare
`Process completed with exit code 1` — no indication of which check failed.

## Fix

Same as #28: read expected versions from the Dockerfile ARGs, and print the
actual value before failing.

## Guard

Added a `validate-config` check for the anti-pattern, since three independent
copies of it existed. Verified it:

- matches **both** original forms (the bare `1.160` and the quoted
  `'"gitVersion": "v1.36'`)
- produces **no false positives** on the current workflows — including the
  deliberate `kubesec version | grep -vq '0.0.0'`, which asserts a version is
  *not* a literal and uses `-vq`

This guard runs on PRs, so it would have caught all three copies before merge.