### PR TITLE
chore: track the DOKS 1.36 cluster in CI tool pins

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -11,13 +11,14 @@ inputs:
     # deploy-cluster-addons, emergency-stop, node-pool-sizing, runner-status,
     # scale-runners) -- all of which talk to the production cluster. Kubernetes
     # supports kubectl within ONE minor of the API server, so this pin must stay
-    # on the cluster's minor. The cluster is 1.33.x, so this is 1.33.x.
+    # on the cluster's minor. The cluster is 1.36.x, so this is 1.36.x.
     #
-    # Do NOT "align" this with docker/Dockerfile.custom-runner's KUBECTL_VERSION.
-    # That one ships to consumer projects targeting arbitrary clusters, so it
-    # tracks latest; matching it here would put emergency-stop and deploy three
-    # minors outside the supported skew. Bump this when the cluster minor moves.
-    default: 'v1.33.13'
+    # Do NOT "align" this with docker/Dockerfile.custom-runner's KUBECTL_VERSION
+    # just because they currently agree. They track different things: that one
+    # ships to consumer projects targeting arbitrary clusters and follows latest,
+    # while this one follows OUR cluster. They will diverge again the next time
+    # upstream kubectl moves ahead of DOKS. Bump this when the cluster minor moves.
+    default: 'v1.36.3'
   helm-version:
     description: 'Helm version to install'
     required: false

--- a/.github/workflows/runner-status.yml
+++ b/.github/workflows/runner-status.yml
@@ -93,9 +93,10 @@ jobs:
       - name: Setup infrastructure tools
         uses: ./.github/actions/setup-tools
         with:
-          kubectl-version: 'v1.33.3'
-          helm-version: 'v3.18.6'
-          doctl-version: 'v1.139.0'
+          # Tool versions intentionally omitted: they come from the action's
+          # defaults, which are the single source of truth. This workflow used
+          # to pin its own copies (v1.33.3 / v3.18.6 / v1.139.0) and silently
+          # missed every bump applied to those defaults.
           install-jq: 'true'
       
       - name: Configure Kubernetes access

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -170,6 +170,25 @@ jobs:
           fi
           echo "✅ No hardcoded tool version assertions"
 
+      - name: Check setup-tools versions are not overridden
+        run: |
+          echo "🔍 Checking for stale setup-tools version overrides..."
+          # The setup-tools action's defaults are the single source of truth for
+          # the kubectl/helm/doctl versions this repo uses against the cluster.
+          # runner-status.yml used to pass its own copies of all three, which
+          # meant it silently kept v1.33.3 / v3.18.6 / v1.139.0 while the
+          # defaults moved on - and its kubectl drifted three minors out of the
+          # supported skew from the API server. Callers should pass only
+          # install-jq and inherit the rest.
+          if grep -rn --exclude=validate-config.yml                -e 'kubectl-version:' -e 'helm-version:' -e 'doctl-version:'                .github/workflows/; then
+            echo ""
+            echo "❌ A workflow pins setup-tools versions (shown above)."
+            echo "   Remove the override and inherit the action's defaults, or"
+            echo "   change the defaults in .github/actions/setup-tools/action.yml."
+            exit 1
+          fi
+          echo "✅ No setup-tools version overrides"
+
       - name: Check runner pod label selectors
         run: |
           echo "🔍 Checking for stale ARC pod label selectors..."

--- a/deploy/dind-values.yaml
+++ b/deploy/dind-values.yaml
@@ -38,7 +38,7 @@ runnerScaleSetName: "redducklabs-runners"
 #
 #   helm template redducklabs-runners \
 #     oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
-#     --version 0.14.2 --kube-version 1.33.12 -f deploy/dind-values.yaml
+#     --version 0.14.2 --kube-version 1.36.3 -f deploy/dind-values.yaml
 #
 # Anything we now own that the chart used to own:
 #   - init-dind-externals init container

--- a/test/verify-runner-resources.sh
+++ b/test/verify-runner-resources.sh
@@ -24,7 +24,7 @@ NC='\033[0m'
 
 CHART="oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set"
 CHART_VERSION="${CHART_VERSION:-0.14.2}"
-KUBE_VERSION="${KUBE_VERSION:-1.33.12}"
+KUBE_VERSION="${KUBE_VERSION:-1.36.3}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"


### PR DESCRIPTION
The cluster was upgraded **1.33.12-do.1 → 1.36.3-do.2** (four hops — DOKS only
ever offers the next reachable target, so it is a walk, not a jump). These pins
follow the cluster, so they have to move with it.

| Pin | Before | After |
|---|---|---|
| `setup-tools` kubectl default | v1.33.13 | **v1.36.3** |
| `verify-runner-resources.sh` `KUBE_VERSION` | 1.33.12 | **1.36.3** |
| `dind-values.yaml` regenerate comment | 1.33.12 | 1.36.3 |

**This is the same rule as #25, applied in the opposite direction.** That PR
kept kubectl on 1.33 because the cluster was on 1.33 and matching the image's
1.36 would have been three minors *ahead* of the API server. The cluster is now
1.36, so v1.33.13 is three minors *behind* — equally outside the supported skew.
The comment in `action.yml` said "bump this when the cluster minor moves"; it
moved.

Note the pin now coincidentally equals the image's `KUBECTL_VERSION`. The
comment has been updated to say they still track different things and will
diverge again the next time upstream kubectl moves ahead of DOKS.

## A drift trap this surfaced

`runner-status.yml` passed its **own copies** of all three versions:

```yaml
kubectl-version: 'v1.33.3'
helm-version: 'v3.18.6'
doctl-version: 'v1.139.0'
```

Those were the action's defaults once. Because they were duplicated into the
caller, that workflow **silently missed the bump in #25** and would have missed
this one too — leaving its kubectl three minors out of skew while everything
else moved. Removed the overrides so it inherits the defaults.

Added a `validate-config` guard rejecting any workflow that pins those inputs
again. Verified it fires on the old form, passes on the current tree, and still
allows the action's own input definitions (it only scans `.github/workflows/`).

## Verification

- `./test/verify-runner-resources.sh` passes with the new defaults — chart
  0.14.2 rendered against kube 1.36.3, all memory/sidecar/one-pod-per-node
  invariants intact
- `actionlint` clean, YAML parses, `bash -n` clean
- Live cluster confirmed on 1.36.3 with the dind native sidecar intact
  (`restartPolicy: Always`, 5Gi request / 10Gi limit)